### PR TITLE
feat: 会話送り時にボイス・口パクを継続するオプション追加

### DIFF
--- a/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
@@ -1,5 +1,6 @@
 using BunnyGarden2FixMod.Utils;
 using GB;
+using GB.Scene;
 using HarmonyLib;
 
 namespace BunnyGarden2FixMod.Patches;
@@ -8,11 +9,12 @@ namespace BunnyGarden2FixMod.Patches;
 /// 会話送り（タップ／オート／スキップ）時に、現在再生中のボイスが途中で切れないようにする
 /// パッチ群。
 ///
-/// ConversationWindow は UpdateRoutine / ToNextText の中で GBSystem.StopVoice() を
-/// 呼び出しており、次の台詞に進むたびに現在のボイスが即停止する。
-/// これらのメソッドの実行範囲だけ StopVoice() を no-op にすることで、
-///   - 次の台詞にボイスがある場合: PlayVoice により AudioSource が上書きされ自然に切り替わる
-///   - 次の台詞にボイスがない場合: 現在のボイスが最後まで再生される
+/// ConversationWindow は UpdateRoutine / ToNextText の中で GBSystem.StopVoice() と
+/// EnvSceneBase.FinishLipSync() を呼び出しており、次の台詞に進むたびにボイスと口パクが
+/// 即停止する。これらのメソッドの実行範囲だけ StopVoice / FinishLipSync を no-op にすることで、
+///   - 次の台詞にボイスがある場合: PlayVoice / StartLipSync により自然に切り替わる
+///   - 次の台詞にボイスがない場合: 現在のボイスが最後まで再生され、口パクも
+///     LipSyncCalculator の自己終了判定で自動的に停止する
 /// という挙動を得る。
 ///
 /// ConversationWindow.ForceFinish（シーン遷移）や ASMR / HolidayAfterScene などの
@@ -93,6 +95,23 @@ public static class ContinueVoiceOnTap_StopVoicePatch
     {
         if (Plugin.ConfigContinueVoiceOnTap.Value && ContinueVoiceState.SuppressDepth > 0)
             return false; // 元の StopVoice を実行しない
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(EnvSceneBase), nameof(EnvSceneBase.FinishLipSync))]
+public static class ContinueVoiceOnTap_FinishLipSyncPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ContinueVoiceOnTapPatch] EnvSceneBase.FinishLipSync の抑制ゲートを登録");
+        return true;
+    }
+
+    private static bool Prefix()
+    {
+        if (Plugin.ConfigContinueVoiceOnTap.Value && ContinueVoiceState.SuppressDepth > 0)
+            return false; // 元の FinishLipSync を実行しない（LipSyncCalculator が音声終了時に自動停止）
         return true;
     }
 }

--- a/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
@@ -1,0 +1,98 @@
+using BunnyGarden2FixMod.Utils;
+using GB;
+using HarmonyLib;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// 会話送り（タップ／オート／スキップ）時に、現在再生中のボイスが途中で切れないようにする
+/// パッチ群。
+///
+/// ConversationWindow は UpdateRoutine / ToNextText の中で GBSystem.StopVoice() を
+/// 呼び出しており、次の台詞に進むたびに現在のボイスが即停止する。
+/// これらのメソッドの実行範囲だけ StopVoice() を no-op にすることで、
+///   - 次の台詞にボイスがある場合: PlayVoice により AudioSource が上書きされ自然に切り替わる
+///   - 次の台詞にボイスがない場合: 現在のボイスが最後まで再生される
+/// という挙動を得る。
+///
+/// ConversationWindow.ForceFinish（シーン遷移）や ASMR / HolidayAfterScene などの
+/// 会話ウィンドウ外経路の StopVoice 呼び出しは抑制対象外。
+/// ConversationWindow.Setup 経由の初回 textRoutine も抑制対象外だが、Setup 自体は
+/// StopVoice を直接呼ばないため実害はない。
+///
+/// 設計上の前提:
+/// - textRoutine は async void。await を跨いで後続処理が走るが、現行実装では await 後に
+///   StopVoice を呼ぶのは ToNextText 経由のみのため、ToNextText をラップすれば十分。
+///   将来 textRoutine の await 以降で直接 StopVoice を呼ぶ改変がゲーム本体に入った場合は
+///   抑制が届かなくなる点に注意。
+/// </summary>
+/// <remarks>
+/// スコープは ContinueVoiceOnTap_*Patch 専用の state ホルダ。
+/// </remarks>
+internal static class ContinueVoiceState
+{
+    // Unity メインスレッド専用。Harmony のパッチは呼び出し元と同じスレッドで走るため
+    // 単純な static int で十分であり、[ThreadStatic] は不要。
+    public static int SuppressDepth;
+}
+
+[HarmonyPatch(typeof(ConversationWindow), nameof(ConversationWindow.UpdateRoutine))]
+public static class ContinueVoiceOnTap_UpdateRoutinePatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ContinueVoiceOnTapPatch] ConversationWindow.UpdateRoutine をラップ");
+        return true;
+    }
+
+    private static void Prefix(out bool __state)
+    {
+        __state = Plugin.ConfigContinueVoiceOnTap.Value;
+        if (__state) ContinueVoiceState.SuppressDepth++;
+    }
+
+    private static void Postfix(bool __state)
+    {
+        if (__state && ContinueVoiceState.SuppressDepth > 0)
+            ContinueVoiceState.SuppressDepth--;
+    }
+}
+
+[HarmonyPatch(typeof(ConversationWindow), nameof(ConversationWindow.ToNextText))]
+public static class ContinueVoiceOnTap_ToNextTextPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ContinueVoiceOnTapPatch] ConversationWindow.ToNextText をラップ");
+        return true;
+    }
+
+    private static void Prefix(out bool __state)
+    {
+        __state = Plugin.ConfigContinueVoiceOnTap.Value;
+        if (__state) ContinueVoiceState.SuppressDepth++;
+    }
+
+    private static void Postfix(bool __state)
+    {
+        if (__state && ContinueVoiceState.SuppressDepth > 0)
+            ContinueVoiceState.SuppressDepth--;
+    }
+}
+
+[HarmonyPatch(typeof(GBSystem), nameof(GBSystem.StopVoice))]
+public static class ContinueVoiceOnTap_StopVoicePatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ContinueVoiceOnTapPatch] GBSystem.StopVoice の抑制ゲートを登録");
+        return true;
+    }
+
+    private static bool Prefix()
+    {
+        if (Plugin.ConfigContinueVoiceOnTap.Value && ContinueVoiceState.SuppressDepth > 0)
+            return false; // 元の StopVoice を実行しない
+        return true;
+    }
+}

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -36,6 +36,7 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<float> ConfigSlowSpeed;
     public static ConfigEntry<bool> ConfigCheatEnabled;
     public static ConfigEntry<bool> ConfigDisableStockings;
+    public static ConfigEntry<bool> ConfigContinueVoiceOnTap;
 
     private GameObject freeCamObject;
     private Camera freeCam;
@@ -102,6 +103,13 @@ public class Plugin : BaseUnityPlugin
             false,
             "true にするとキャストのストッキングを非表示にします。\n" +
             "ApplyStocking の type 引数を強制的に 0（なし）に置き換えます。");
+
+        ConfigContinueVoiceOnTap = Config.Bind(
+            "Conversation",
+            "ContinueVoiceOnTap",
+            false,
+            "true にすると会話送り（タップ／オート／スキップ）時にボイスが途中停止せず、\n" +
+            "次の台詞のボイス再生で自然に上書きされるか、ボイスが最後まで再生されるようになります。");
 
         ConfigCheatEnabled = Config.Bind(
             "Cheat",

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [バニーガーデン2](https://store.steampowered.com/app/3443820/2/)(海外名:Bunny Garden2)用の解像度修正やフレームレート上限変更などを行うBepInEx5用Modです。
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b4e45f40-5420-4811-8500-4a0c3b4d1e69" />
-<img width="1920" height="1080" alt="スクリーンショット 2026-04-16 191718-e" src="https://github.com/user-attachments/assets/f6c86e6b-2ad5-4b5f-bfa8-6ff66fcaf43b" />
+<img width="1920" height="1000" alt="スクリーンショット 2026-04-16 191718-e" src="https://github.com/user-attachments/assets/f6c86e6b-2ad5-4b5f-bfa8-6ff66fcaf43b" />
 
 ## おしらせ
 バージョン1.0.3から、BepInEx6にも対応しました！！  
 今までのBepInEx5版もひきつづき開発します！！  
 また、下で紹介している導入方法はBepInEx5のものになります！ご了承ください～  
 
-## 対応バージョン(MODバージョンv1.0.3現在)
+## 対応バージョン(MODバージョンv1.0.4現在)
 - ゲームバージョン1.0.1のみ対応  
 
 ## 機能
@@ -17,6 +17,8 @@
 - 本来は60で固定されていたフレームレート制限を任意の値にするか、取り払うことができる。
 - アンチエイリアスを設定し、さらに画面のガビガビ感(ジャギー)を減らすことができる。
 - F5キーでON/OFF、F6キーでカメラの固定ができる、フリーカメラ機能。
+- ドリンク、フード、会話選択肢の正解を表示させることが出来る。(デフォルトでは無効)
+- ストッキングを強制的に非表示にすることができる。(デフォルトでは無効)
 
 ## 導入方法(Steam Deckも対応)
 1. [Releases](https://github.com/kazumasa200/BunnyGarden2FixMod/releases/latest)から最新のzipファイルをダウンロードする。(BunnyGarden2FixMod v1.0.0.zipみたいな感じ)ブラウザによってはブロックするかもしれないので注意。<br>導入時の最新バージョンを入れてください。

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@
 <img width="1490" height="383" alt="image" src="https://github.com/user-attachments/assets/f24310e1-c5f1-4a08-9195-b25d0fe37377" />
 
 6. もう一度起動するとBepinExフォルダの中のconfigフォルダに```net.noeleve.BunnyGarden2FixMod.cfg```設定ファイルが出来上がるので、それをメモ帳などで変更して解像度の設定やフレームレートなどの設定をする。
-<img width="1425" height="748" alt="image" src="https://github.com/user-attachments/assets/14eb1538-503f-4c36-8630-62e9f008c0cb" />
+<img width="1677" height="1906" alt="image" src="https://github.com/user-attachments/assets/d8cdc40e-7299-46f4-bbf0-ba5d685c38c9" />
+
 
 ## 既知の問題点
 [Issues](https://github.com/kazumasa200/BunnyGarden2FixMod/issues)をご確認ください。バグや改善点、ほしい機能ありましたら[Issues](https://github.com/kazumasa200/BunnyGarden2FixMod/issues)もしくは[X](https://x.com/kazumasa200)までお願いします。  

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 
 6. もう一度起動するとBepinExフォルダの中のconfigフォルダに```net.noeleve.BunnyGarden2FixMod.cfg```設定ファイルが出来上がるので、それをメモ帳などで変更して解像度の設定やフレームレートなどの設定をする。
 <img width="1677" height="1906" alt="image" src="https://github.com/user-attachments/assets/d8cdc40e-7299-46f4-bbf0-ba5d685c38c9" />
+上の画像は例です。お好みにどうぞ。
 
 
 ## 既知の問題点


### PR DESCRIPTION
## 概要
会話送り（タップ／オート／スキップ）のたびにボイスと口パクが即停止する挙動を
抑制する任意オプションを追加する。`BepInEx/config/net.noeleve.BunnyGarden2FixMod.cfg`
の `[Conversation] ContinueVoiceOnTap=true` で有効化される（デフォルト `false` = 既存挙動）。

## 主な変更点
### 機能追加
- `ConversationWindow.UpdateRoutine` / `ToNextText` の実行範囲を抑制スコープとし、
  その間の `GBSystem.StopVoice` と `EnvSceneBase.FinishLipSync` を Harmony Prefix で no-op 化
- 次の台詞にボイスがある場合 → `PlayVoice` / `StartLipSync` により自然に上書き
- 次の台詞にボイスがない場合 → 現在のボイスが再生終了するまで継続し、
  `LipSyncCalculator` の自己終了判定で口パクも自動停止
- `ConversationWindow.ForceFinish`（シーン遷移）や ASMR / HolidayAfterScene など
  会話ウィンドウ外経路の停止呼び出しは影響を受けない

## 変更ファイル一覧
- `BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs` - 新規。SuppressDepth ゲートと 4 つの HarmonyPatch
- `BunnyGarden2FixMod/Plugin.cs` - `ConfigContinueVoiceOnTap` ConfigEntry 追加

## 技術的な補足
- 抑制ゲートは static int の depth カウンタで管理（Unity メインスレッド前提のため `[ThreadStatic]` 不要）
- Prefix で `out bool __state` に config 値をキャプチャし、Postfix で自身が increment した
  場合のみ decrement することで、config 動的切替時も depth が不整合にならない
- `textRoutine` は async void のため await を跨ぐが、現行ゲーム本体は await 以降で
  StopVoice / FinishLipSync を直接呼ばず、必ず `ToNextText` 経由となるため、
  `ToNextText` をラップすれば網羅できる（設計前提は xmldoc に明記）

## レビューのポイント
- `BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs` — 抑制スコープの妥当性、
  特に `ForceFinish`・ASMR・HolidayAfterScene が対象外であることの確認
- `BunnyGarden2FixMod/Plugin.cs` — Config セクションの命名（`[Conversation]` 新設）

## テスト
- [x] `dotnet build`（BepInEx 5 / 6 双方）成功
- [ ] 手動テスト実施内容：
  - 会話中にタップで次に送っても前台詞のボイスが最後まで鳴ること
  - 次台詞にボイスがある場合は上書き再生されること
  - 口パクがボイスに追従して動き、ボイス終了時に自然に止まること
  - シーン遷移時（ForceFinish）にボイスが正しく止まること
  - config OFF 時は従来挙動のままであること
  - ASMR / HolidayAfterScene など他のボイス停止経路に副作用がないこと

## 破壊的変更
なし（デフォルト OFF・既存挙動は変わらない）

---

## QA 確認項目

▼ どんな変更をして何を解決したか？
会話中にタップして次の台詞に送ると、再生中のボイスが途中で切れる仕様だった。
本 PR の機能を ON にすると、ボイスが最後まで鳴るか次のボイスに自然に切り替わるようになる。
口パクもボイスに連動する。

▼ 既存影響あるか？
なし（デフォルト OFF。`[Conversation] ContinueVoiceOnTap=true` で明示的に有効化した場合のみ挙動変化）

▼ 期待値
1. 正常なケース（ContinueVoiceOnTap=true）:
   - タップ送り中にボイスが途切れない
   - 次台詞にボイスがあれば自然に切り替わる
   - 口パクがボイス再生の間だけ動く
2. 正常なケース（ContinueVoiceOnTap=false / デフォルト）:
   - 従来通り、タップするとボイスが即停止する
3. 異常なケース:
   - シーン遷移／ASMR／HolidayAfterScene でボイスが止まらない事象がないこと

▼ 確認内容
1. \`BepInEx/config/net.noeleve.BunnyGarden2FixMod.cfg\` の \`[Conversation] ContinueVoiceOnTap = true\` を設定
2. ゲーム内で任意のキャストと会話開始、タップで次の台詞に送る
3. 前台詞のボイスが最後まで鳴る／次のボイスに自然に切り替わることを確認
4. 口パクがボイスに追従していることを確認
5. 設定を \`false\` に戻し、従来通りタップで即停止することを確認
6. シーン離脱時にボイスが残らないことを確認