### PR TITLE
feat(cheki): チェキ高解像度化と MOD 用サイドカーセーブ基盤を追加

### DIFF
--- a/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
+++ b/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
@@ -44,10 +44,13 @@
 
   <ItemGroup>
     <None Remove="Assembly\Assembly-CSharp.dll" />
+    <None Remove="Assembly\UniTask.dll" />
     <None Remove="Assembly\Unity.InputSystem.dll" />
     <None Remove="Assembly\Unity.RenderPipelines.Universal.Runtime.dll" />
     <None Remove="Assembly\Unity.TextMeshPro.dll" />
     <None Remove="Assembly\UnityEngine.UI.dll" />
+    <None Remove="Assembly\MessagePack.dll" />
+    <None Remove="Assembly\MessagePack.Annotations.dll" />
   </ItemGroup>
 
   <!-- BepInEx 5 用パッケージ -->
@@ -74,6 +77,9 @@
     <Reference Include="Assembly-CSharp" Publicize="true">
       <HintPath>Assembly\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="UniTask">
+      <HintPath>Assembly\UniTask.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.RenderPipelines.Universal.Runtime">
       <HintPath>Assembly\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
     </Reference>
@@ -85,6 +91,14 @@
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>Assembly\UnityEngine.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="MessagePack">
+      <HintPath>Assembly\MessagePack.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="MessagePack.Annotations">
+      <HintPath>Assembly\MessagePack.Annotations.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 </Project>

--- a/BunnyGarden2FixMod/ExSave/ExSaveData.cs
+++ b/BunnyGarden2FixMod/ExSave/ExSaveData.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using BunnyGarden2FixMod.Utils;
+using MessagePack;
+
+namespace BunnyGarden2FixMod.ExSave;
+
+/// <summary>
+/// .exmod サイドカーのルート構造。saveSlotId 毎に <see cref="ExSaveSlotData"/> を持つ。
+/// 直列化は MessagePack (LZ4BlockArray 圧縮)。
+///
+/// <para>
+/// 破損時は <see cref="Deserialize"/> で空データを返し、主セーブには一切触らないフェイルセーフ。
+/// </para>
+/// </summary>
+[MessagePackObject]
+public class ExSaveData
+{
+    /// <summary>saveSlotId → ExSaveSlotData。キーは 0..8 を想定。</summary>
+    [Key(0)]
+    public Dictionary<int, ExSaveSlotData> Slots { get; set; } = new();
+
+    /// <summary>格納されているスロット数。</summary>
+    [IgnoreMember]
+    public int Count => Slots.Count;
+
+    /// <summary>ゲーム本体と同じ LZ4BlockArray 圧縮オプション。</summary>
+    private static readonly MessagePackSerializerOptions s_options =
+        MessagePackSerializerOptions.Standard
+            .WithCompression(MessagePackCompression.Lz4BlockArray);
+
+    /// <summary>指定スロットが存在すれば返す。存在しなければ新規作成して登録する。</summary>
+    public ExSaveSlotData GetOrCreateSlot(int saveSlot)
+    {
+        if (!Slots.TryGetValue(saveSlot, out var slot))
+        {
+            slot = new ExSaveSlotData();
+            Slots[saveSlot] = slot;
+        }
+        return slot;
+    }
+
+    /// <summary>指定スロットが存在すれば out に返す。</summary>
+    public bool TryGetSlot(int saveSlot, out ExSaveSlotData slot) =>
+        Slots.TryGetValue(saveSlot, out slot);
+
+    /// <summary>指定スロットを削除する。</summary>
+    public bool RemoveSlot(int saveSlot) => Slots.Remove(saveSlot);
+
+    /// <summary>指定スロットが存在するか確認する。</summary>
+    public bool HasSlot(int saveSlot) => Slots.ContainsKey(saveSlot);
+
+    /// <summary>
+    /// MessagePack 直列化。LZ4BlockArray 圧縮を適用する。
+    /// 例外は呼び出し側（ExSaveStore.SaveToPathAsync）の try/catch に委ねる。
+    /// </summary>
+    /// <exception cref="MessagePackSerializationException">
+    /// スキーマ不整合や LZ4 圧縮失敗時に送出される可能性。
+    /// </exception>
+    public byte[] Serialize() => MessagePackSerializer.Serialize(this, s_options);
+
+    /// <summary>
+    /// MessagePack で逆直列化する。失敗時・null 要素検出時は空ないしデフォルトに差し替えてフェイルセーフ。
+    /// </summary>
+    public static ExSaveData Deserialize(byte[] bytes)
+    {
+        if (bytes == null || bytes.Length == 0) return new ExSaveData();
+        try
+        {
+            var data = MessagePackSerializer.Deserialize<ExSaveData>(bytes, s_options);
+            if (data == null) return new ExSaveData();
+            data.Slots ??= new Dictionary<int, ExSaveSlotData>();
+
+            // 欠損キー / 他言語ツール由来の null 要素を正規化
+            var nullKeys = new List<int>();
+            foreach (var kv in data.Slots)
+            {
+                if (kv.Value == null) { nullKeys.Add(kv.Key); continue; }
+                kv.Value.Entries ??= new Dictionary<string, byte[]>();
+                // Entries 内の null バイト列を空配列に正規化（他言語ツール由来の .exmod 想定）
+                List<string> entryNullKeys = null;
+                foreach (var ek in kv.Value.Entries)
+                {
+                    if (ek.Value == null)
+                    {
+                        entryNullKeys ??= new List<string>();
+                        entryNullKeys.Add(ek.Key);
+                    }
+                }
+                if (entryNullKeys != null)
+                    foreach (var ek in entryNullKeys)
+                        kv.Value.Entries[ek] = Array.Empty<byte>();
+            }
+            foreach (var k in nullKeys)
+                data.Slots[k] = new ExSaveSlotData();
+
+            return data;
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[ExSave] Deserialize 失敗、空データで続行: {ex}");
+            return new ExSaveData();
+        }
+    }
+}

--- a/BunnyGarden2FixMod/ExSave/ExSaveSlotData.cs
+++ b/BunnyGarden2FixMod/ExSave/ExSaveSlotData.cs
@@ -9,11 +9,6 @@ namespace BunnyGarden2FixMod.ExSave;
 /// <see cref="ExSaveData"/> の各スロット要素として格納される。
 ///
 /// <para>
-/// メソッド群は旧 <see cref="ExSaveData"/> の API を踏襲し、
-/// <c>ChekiSaveHiResPatch</c> / <c>ChekiItemLoadHiResPatch</c> から透過的に使用できる。
-/// </para>
-///
-/// <para>
 /// 直列化は MessagePack 属性付き POCO として <see cref="ExSaveData"/> が一括担当する。
 /// このクラス自身は entry 列の操作 API を提供する。
 /// </para>

--- a/BunnyGarden2FixMod/ExSave/ExSaveSlotData.cs
+++ b/BunnyGarden2FixMod/ExSave/ExSaveSlotData.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace BunnyGarden2FixMod.ExSave;
+
+/// <summary>
+/// 単一セーブスロット単位の key/value ストア。
+/// <see cref="ExSaveData"/> の各スロット要素として格納される。
+///
+/// <para>
+/// メソッド群は旧 <see cref="ExSaveData"/> の API を踏襲し、
+/// <c>ChekiSaveHiResPatch</c> / <c>ChekiItemLoadHiResPatch</c> から透過的に使用できる。
+/// </para>
+///
+/// <para>
+/// 直列化は MessagePack 属性付き POCO として <see cref="ExSaveData"/> が一括担当する。
+/// このクラス自身は entry 列の操作 API を提供する。
+/// </para>
+/// </summary>
+[MessagePackObject]
+public class ExSaveSlotData
+{
+    /// <summary>汎用 key/value ストア。key は <c>cheki.hires.{n}</c> 等。value は PNG/JPG バイト列。</summary>
+    [Key(0)]
+    public Dictionary<string, byte[]> Entries { get; set; } = new();
+
+    /// <summary>格納されているエントリ数。</summary>
+    [IgnoreMember]
+    public int Count => Entries.Count;
+
+    /// <summary>指定キーの値を取り出す。</summary>
+    public bool TryGet(string key, out byte[] value) => Entries.TryGetValue(key, out value);
+
+    /// <summary>
+    /// 指定したキーにバイト列を格納する。
+    /// <paramref name="value"/> が null の場合は <see cref="Array.Empty{T}"/> に正規化して格納する（往復非対称を防ぐ）。
+    /// </summary>
+    public void Set(string key, byte[] value) =>
+        Entries[key] = value ?? Array.Empty<byte>();
+
+    /// <summary>指定キーのエントリを削除する。</summary>
+    public bool Remove(string key) => Entries.Remove(key);
+
+    /// <summary>指定キーが存在するか確認する。</summary>
+    public bool Has(string key) => Entries.ContainsKey(key);
+
+    /// <summary>全エントリを削除する。</summary>
+    public void Clear() => Entries.Clear();
+
+    /// <summary>全エントリをディープコピーした新しいインスタンスを返す。</summary>
+    public ExSaveSlotData CloneDeep()
+    {
+        var clone = new ExSaveSlotData();
+        foreach (var kv in Entries)
+        {
+            // Set で null→空に正規化されているため null は来ないはずだが、
+            // Deserialize 直後に外部由来の null が残る可能性に備えて防御する。
+            clone.Entries[kv.Key] = kv.Value == null
+                ? Array.Empty<byte>()
+                : (byte[])kv.Value.Clone();
+        }
+        return clone;
+    }
+}

--- a/BunnyGarden2FixMod/ExSave/ExSaveStore.cs
+++ b/BunnyGarden2FixMod/ExSave/ExSaveStore.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BunnyGarden2FixMod.Utils;
+using GB.Save;
+using GB.Save.Pc;
+using GB.Save.Steam;
+
+namespace BunnyGarden2FixMod.ExSave;
+
+/// <summary>
+/// <see cref="ExSaveData"/> の静的アクセサ兼パスリゾルバ。セーブスロット追跡もここで管理する。
+/// ゲーム側の <c>Saves.Load</c> / <c>Saves.Save</c> ライフサイクルに同期して読み書きされる。
+///
+/// <para>
+/// ゲーム本体の「GameData (現在) / SavedGameData[9] (スロット別スナップショット)」の
+/// 関係を MOD 側でも模倣する:
+/// <list type="bullet">
+///   <item><term><see cref="AllSlots"/></term><description>永続化全体（ファイル内容）</description></item>
+///   <item><term><see cref="CurrentSession"/></term><description>現在プレイ中の作業セット（GameData 対応）</description></item>
+///   <item><term><see cref="CurrentSaveSlot"/></term><description>ロード/セーブ先スロット。-1 = セーブ不可（新規ゲーム直後・アルバム閲覧中等）</description></item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// サイドカーファイルは主セーブパスに <c>.exmod</c> を付与した位置に置かれる（同ディレクトリ）。
+/// たとえば主セーブが <c>save_00.dat</c> なら <c>save_00.dat.exmod</c>。
+/// </para>
+/// </summary>
+public static class ExSaveStore
+{
+    private const string SidecarExtension = ".exmod";
+
+    /// <summary>永続化全体のデータ（全スロット分）。ファイルに読み書きされる。</summary>
+    public static ExSaveData AllSlots { get; private set; } = new ExSaveData();
+
+    /// <summary>
+    /// 現在プレイ中のセッション（GameData に対応するスロット相当）。
+    /// チェキ撮影や閲覧時はここに読み書きする。
+    /// </summary>
+    public static ExSaveSlotData CurrentSession { get; private set; } = new ExSaveSlotData();
+
+    /// <summary>
+    /// 現在のロード/セーブ先スロット番号。
+    /// -1 の場合は「セーブ不可」マーカー（新規ゲーム直後・アルバム閲覧中等）。
+    /// <c>Saves.Save</c> Postfix wrap ではこの値が 0 以上のときのみ <see cref="CommitSession"/> を実行する。
+    /// </summary>
+    public static int CurrentSaveSlot { get; set; } = -1;
+
+    /// <summary>
+    /// 旧 API 互換プロパティ（v1 デプロイ版で外部から参照されていた可能性のある API）。
+    /// v2 では <see cref="CurrentSession"/> を直接使用すること。
+    /// </summary>
+    [Obsolete("ExSaveStore.Current は将来バージョンで削除予定です。ExSaveStore.CurrentSession を使用してください。", false)]
+    public static ExSaveSlotData Current => CurrentSession;
+
+    /// <summary>現在のセーブに対応する主セーブのパス（Load/Save 後に確定）。null の間は I/O スキップ。</summary>
+    public static string CurrentMainPath { get; private set; }
+
+    public static string GetSidecarPath(string mainSavePath)
+    {
+        if (string.IsNullOrEmpty(mainSavePath)) return null;
+        return mainSavePath + SidecarExtension;
+    }
+
+    /// <summary>
+    /// <see cref="Saves"/> の具象インスタンスから主セーブファイルパスを取り出す。
+    /// <c>SteamSave</c> / <c>PcSave</c> は <c>Paths</c> public プロパティを持つため
+    /// リフレクションなしで取得可能。未知の具象は null を返す。
+    /// </summary>
+    public static string TryResolveMainPath(Saves saves)
+    {
+        if (saves == null) return null;
+        try
+        {
+            if (saves is SteamSave steam && steam.Paths != null && steam.Paths.Count > 0)
+                return steam.Paths[0];
+            if (saves is PcSave pc && pc.Paths != null && pc.Paths.Count > 0)
+                return pc.Paths[0];
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[ExSave] 主セーブパス解決失敗: {ex.Message}");
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 全状態をリセットする（新規ゲーム作成時に使用）。
+    /// AllSlots / CurrentSession / CurrentSaveSlot / CurrentMainPath を全て初期化する。
+    /// </summary>
+    public static void Reset()
+    {
+        AllSlots = new ExSaveData();
+        CurrentSession = new ExSaveSlotData();
+        CurrentSaveSlot = -1;
+        CurrentMainPath = null;
+    }
+
+    /// <summary>
+    /// セッション状態のみリセットする（ロード完了後に使用）。
+    /// AllSlots / CurrentMainPath は変更しない。
+    /// CurrentSession を空にし、CurrentSaveSlot = -1 にする。
+    /// </summary>
+    public static void ResetSession()
+    {
+        CurrentSession = new ExSaveSlotData();
+        CurrentSaveSlot = -1;
+    }
+
+    /// <summary>
+    /// <see cref="AllSlots"/> の saveSlot 番目の内容を <see cref="CurrentSession"/> に
+    /// ディープコピーし、<see cref="CurrentSaveSlot"/> = saveSlot をセットする。
+    /// 該当スロットが存在しない場合は <see cref="CurrentSession"/> が空になる。
+    /// </summary>
+    public static void LoadSession(int saveSlot)
+    {
+        if (AllSlots.TryGetSlot(saveSlot, out var slotData))
+        {
+            CurrentSession = slotData.CloneDeep();
+        }
+        else
+        {
+            CurrentSession = new ExSaveSlotData();
+        }
+        CurrentSaveSlot = saveSlot;
+    }
+
+    /// <summary>
+    /// <see cref="CurrentSession"/> を <see cref="AllSlots"/> の saveSlot 番目に
+    /// ディープコピーで書き戻す。<see cref="CurrentSaveSlot"/> は変更しない。
+    /// </summary>
+    public static void CommitSession(int saveSlot)
+    {
+        var slot = AllSlots.GetOrCreateSlot(saveSlot);
+        // 既存スロットを CurrentSession の内容で上書きする
+        slot.Clear();
+        foreach (var kv in CurrentSession.Entries)
+        {
+            // Set / Deserialize で正規化されるため到達想定なし。防御のみ。
+            byte[] src = kv.Value ?? Array.Empty<byte>();
+            byte[] copy = new byte[src.Length];
+            Buffer.BlockCopy(src, 0, copy, 0, src.Length);
+            slot.Set(kv.Key, copy);
+        }
+    }
+
+    public static void LoadFromPath(string mainSavePath)
+    {
+        CurrentMainPath = mainSavePath;
+        string path = GetSidecarPath(mainSavePath);
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            AllSlots = new ExSaveData();
+            PatchLogger.LogInfo($"[ExSave] サイドカー無し、空データで開始: {path ?? "(null)"}");
+            return;
+        }
+        try
+        {
+            byte[] bytes = File.ReadAllBytes(path);
+            AllSlots = ExSaveData.Deserialize(bytes);
+            int totalEntries = 0;
+            foreach (var kv in AllSlots.Slots)
+                totalEntries += kv.Value?.Count ?? 0;
+            PatchLogger.LogInfo($"[ExSave] ロード: {path} ({bytes.Length} bytes, {AllSlots.Slots.Count} slots, {totalEntries} entries)");
+        }
+        catch (Exception ex)
+        {
+            AllSlots = new ExSaveData();
+            PatchLogger.LogWarning($"[ExSave] ロード失敗、空データで続行: {path} ({ex})");
+        }
+    }
+
+    public static async Task SaveToPathAsync(string mainSavePath)
+    {
+        string path = GetSidecarPath(mainSavePath);
+        if (string.IsNullOrEmpty(path))
+        {
+            PatchLogger.LogWarning("[ExSave] 主セーブパス未確定のため保存をスキップ");
+            return;
+        }
+        try
+        {
+            // 先に同期でスナップショット化してから await に入る。
+            // これにより WriteAllBytesAsync 中に AllSlots に書き込みが入っても既にコピー済みで列挙例外を避けられる。
+            byte[] bytes = AllSlots.Serialize();
+            string dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+            int totalEntries = 0;
+            foreach (var kv in AllSlots.Slots)
+                totalEntries += kv.Value?.Count ?? 0;
+            PatchLogger.LogInfo($"[ExSave] 保存: {path} ({bytes.Length} bytes, {AllSlots.Slots.Count} slots, {totalEntries} entries)");
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ExSave] 保存失敗: {path} ({ex})");
+        }
+    }
+}

--- a/BunnyGarden2FixMod/ExSave/ExSaveStore.cs
+++ b/BunnyGarden2FixMod/ExSave/ExSaveStore.cs
@@ -47,13 +47,6 @@ public static class ExSaveStore
     /// </summary>
     public static int CurrentSaveSlot { get; set; } = -1;
 
-    /// <summary>
-    /// 旧 API 互換プロパティ（v1 デプロイ版で外部から参照されていた可能性のある API）。
-    /// v2 では <see cref="CurrentSession"/> を直接使用すること。
-    /// </summary>
-    [Obsolete("ExSaveStore.Current は将来バージョンで削除予定です。ExSaveStore.CurrentSession を使用してください。", false)]
-    public static ExSaveSlotData Current => CurrentSession;
-
     /// <summary>現在のセーブに対応する主セーブのパス（Load/Save 後に確定）。null の間は I/O スキップ。</summary>
     public static string CurrentMainPath { get; private set; }
 

--- a/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
@@ -33,8 +33,8 @@ namespace BunnyGarden2FixMod.Patches;
 [HarmonyPatch(typeof(ChekiItem), nameof(ChekiItem.SetupCheki))]
 public static class ChekiItemLoadHiResPatch
 {
-    private const int SizeMin = 64;
-    private const int SizeMax = 2048;
+    internal const int SizeMin = 64;
+    internal const int SizeMax = 2048;
 
     private static AccessTools.FieldRef<ChekiItem, Texture2D> s_textureRef;
     private static AccessTools.FieldRef<ChekiItem, Sprite> s_spriteRef;
@@ -124,13 +124,18 @@ public static class ChekiItemLoadHiResPatch
     /// payload を magic byte で自動判別してデコードする。読み込み失敗・検証エラー時は null を返し、
     /// 呼び出し側は vanilla 320 にフォールバックする。成功時は呼び出し側が <c>Destroy</c> 責任を持つ。
     ///
+    /// <para>
+    /// <paramref name="logPrefix"/> は警告ログのプレフィックス（呼び出し元のパッチ名等）。
+    /// 他パッチ（<c>EndingChekiSlideshowHiResPatch</c> 等）からも再利用できるよう internal で公開。
+    /// </para>
+    ///
     /// <list type="bullet">
     ///   <item>先頭 <c>89 50 4E 47</c> (PNG) → <c>ImageConversion.LoadImage</c></item>
     ///   <item>先頭 <c>FF D8 FF</c> (JPG) → <c>ImageConversion.LoadImage</c></item>
     ///   <item>それ以外 → 未対応フォーマット、警告ログ＋null 返却（vanilla 320 にフォールバック）</item>
     /// </list>
     /// </summary>
-    private static Texture2D DecodePayload(byte[] payload, int slot)
+    internal static Texture2D DecodePayload(byte[] payload, int slot, string logPrefix = "[ChekiItemLoadHiResPatch]")
     {
         // PNG magic: 89 50 4E 47
         bool isPng = payload.Length >= 4
@@ -142,7 +147,7 @@ public static class ChekiItemLoadHiResPatch
 
         if (!isPng && !isJpg)
         {
-            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] 未対応フォーマット slot={slot}、vanilla 320 にフォールバック");
+            PatchLogger.LogWarning($"{logPrefix} 未対応フォーマット slot={slot}、vanilla 320 にフォールバック");
             return null;
         }
 
@@ -156,20 +161,20 @@ public static class ChekiItemLoadHiResPatch
         }
         catch (Exception ex)
         {
-            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] LoadImage 例外 slot={slot}: {ex.Message}");
+            PatchLogger.LogWarning($"{logPrefix} LoadImage 例外 slot={slot}: {ex.Message}");
             UnityEngine.Object.Destroy(tex);
             return null;
         }
         if (!ok)
         {
-            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] LoadImage 失敗 slot={slot}");
+            PatchLogger.LogWarning($"{logPrefix} LoadImage 失敗 slot={slot}");
             UnityEngine.Object.Destroy(tex);
             return null;
         }
         // 破損 / 攻撃的 payload に備え、サイズを検証（正方形・範囲内）。
         if (tex.width != tex.height || tex.width < SizeMin || tex.width > SizeMax)
         {
-            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] デコード後サイズ不正 slot={slot} {tex.width}x{tex.height}、スキップ");
+            PatchLogger.LogWarning($"{logPrefix} デコード後サイズ不正 slot={slot} {tex.width}x{tex.height}、スキップ");
             UnityEngine.Object.Destroy(tex);
             return null;
         }

--- a/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
@@ -63,7 +63,9 @@ public static class ChekiItemLoadHiResPatch
         if (gameData == null) return;
 
         // slot 範囲外は受け付けない（異常系 / 悪意のある .exmod 防御）。
-        if (slot < 0 || slot >= ChekiSaveHiResPatch.MaxSlot) return;
+        // 配列長は ChekiSaveHiResPatch の FieldRef 経由で本体から動的取得。
+        int slotCount = ChekiSaveHiResPatch.GetSlotCount(gameData);
+        if (slotCount < 0 || slot < 0 || slot >= slotCount) return;
 
         string key = ChekiSaveHiResPatch.KeyFor(slot);
 

--- a/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
@@ -1,0 +1,176 @@
+using System;
+using BunnyGarden2FixMod.ExSave;
+using BunnyGarden2FixMod.Utils;
+using GB.Game;
+using GB.ListSelector;
+using HarmonyLib;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.UI;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// <see cref="ChekiItem.SetupCheki"/> の Postfix で、ExSave に高解像度版があれば
+/// <c>m_chekiTexture</c> / <c>m_chekiSprite</c> を差し替えるパッチ。
+///
+/// <para>
+/// <b>フォールバック:</b>
+/// <list type="bullet">
+///   <item><see cref="Plugin.ConfigChekiHighResEnabled"/> が false → 何もしない（vanilla 320）</item>
+///   <item><c>gameData.IsChekiValid(slot)</c> が false → 何もしない（vanilla の鍵アイコン表示）</item>
+///   <item>ExSave に該当エントリが無い → 何もしない（vanilla 320）</item>
+///   <item>ペイロード破損（未対応 magic / LoadImage 失敗 / サイズ範囲外）→ 何もしない（警告ログのみ）</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// vanilla の 320 が先に貼られているので、差し替え時は旧 Texture2D/Sprite を Destroy してから
+/// 新規を <c>m_chekiImg.sprite</c> に差し込む。<c>ChekiItem.PurgeTexture</c> が再撮影時に
+/// 旧テクスチャを破棄してくれる構造なので、その後の整合性も保たれる。
+/// </para>
+/// </summary>
+[HarmonyPatch(typeof(ChekiItem), nameof(ChekiItem.SetupCheki))]
+public static class ChekiItemLoadHiResPatch
+{
+    private const int SizeMin = 64;
+    private const int SizeMax = 2048;
+
+    private static AccessTools.FieldRef<ChekiItem, Texture2D> s_textureRef;
+    private static AccessTools.FieldRef<ChekiItem, Sprite> s_spriteRef;
+    private static AccessTools.FieldRef<ChekiItem, Image> s_imgRef;
+
+    static bool Prepare()
+    {
+        try
+        {
+            s_textureRef = AccessTools.FieldRefAccess<ChekiItem, Texture2D>("m_chekiTexture");
+            s_spriteRef = AccessTools.FieldRefAccess<ChekiItem, Sprite>("m_chekiSprite");
+            s_imgRef = AccessTools.FieldRefAccess<ChekiItem, Image>("m_chekiImg");
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiItemLoadHiResPatch] FieldRef 初期化失敗、パッチ無効化: {ex.Message}");
+            return false;
+        }
+        PatchLogger.LogInfo("[ChekiItemLoadHiResPatch] ChekiItem.SetupCheki をパッチしました（ExSave からの hi-res 差し替え）");
+        return true;
+    }
+
+    private static void Postfix(ChekiItem __instance, GameData gameData, int slot)
+    {
+        if (!Plugin.ConfigChekiHighResEnabled.Value) return;
+        if (gameData == null) return;
+
+        // slot 範囲外は受け付けない（異常系 / 悪意のある .exmod 防御）。
+        if (slot < 0 || slot >= ChekiSaveHiResPatch.MaxSlot) return;
+
+        string key = ChekiSaveHiResPatch.KeyFor(slot);
+
+        // スロットが無効化されている場合は ExSave 側の残留エントリを掃除する（ディスク肥大防止）。
+        if (!gameData.IsChekiValid(slot))
+        {
+            if (ExSaveStore.CurrentSession.Remove(key))
+            {
+                PatchLogger.LogInfo($"[ChekiItemLoadHiResPatch] 無効スロットの ExSave エントリを削除: {key}");
+            }
+            return;
+        }
+
+        if (!ExSaveStore.CurrentSession.TryGet(key, out byte[] payload) || payload == null || payload.Length < 4)
+        {
+            return;
+        }
+
+        Texture2D newTex = null;
+        Sprite newSprite = null;
+        try
+        {
+            newTex = DecodePayload(payload, slot);
+            if (newTex == null) return;
+
+            int w = newTex.width;
+            int h = newTex.height;
+            newSprite = Sprite.Create(newTex, new Rect(0f, 0f, w, h), Vector2.zero);
+
+            // 既存 (vanilla 320) のテクスチャ・スプライトを破棄して差し替え。
+            var oldTex = s_textureRef(__instance);
+            var oldSprite = s_spriteRef(__instance);
+            if (oldTex != null) UnityEngine.Object.Destroy(oldTex);
+            if (oldSprite != null) UnityEngine.Object.Destroy(oldSprite);
+
+            s_textureRef(__instance) = newTex;
+            s_spriteRef(__instance) = newSprite;
+            s_imgRef(__instance).sprite = newSprite;
+
+            // 所有権移譲、finally での破棄対象から外す。
+            newTex = null;
+            newSprite = null;
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiItemLoadHiResPatch] 差し替え失敗 slot={slot}: {ex.Message}");
+        }
+        finally
+        {
+            if (newTex != null) UnityEngine.Object.Destroy(newTex);
+            if (newSprite != null) UnityEngine.Object.Destroy(newSprite);
+        }
+    }
+
+    /// <summary>
+    /// payload を magic byte で自動判別してデコードする。読み込み失敗・検証エラー時は null を返し、
+    /// 呼び出し側は vanilla 320 にフォールバックする。成功時は呼び出し側が <c>Destroy</c> 責任を持つ。
+    ///
+    /// <list type="bullet">
+    ///   <item>先頭 <c>89 50 4E 47</c> (PNG) → <c>ImageConversion.LoadImage</c></item>
+    ///   <item>先頭 <c>FF D8 FF</c> (JPG) → <c>ImageConversion.LoadImage</c></item>
+    ///   <item>それ以外 → 未対応フォーマット、警告ログ＋null 返却（vanilla 320 にフォールバック）</item>
+    /// </list>
+    /// </summary>
+    private static Texture2D DecodePayload(byte[] payload, int slot)
+    {
+        // PNG magic: 89 50 4E 47
+        bool isPng = payload.Length >= 4
+                     && payload[0] == 0x89 && payload[1] == 0x50
+                     && payload[2] == 0x4E && payload[3] == 0x47;
+        // JPG magic: FF D8 FF
+        bool isJpg = payload.Length >= 3
+                     && payload[0] == 0xFF && payload[1] == 0xD8 && payload[2] == 0xFF;
+
+        if (!isPng && !isJpg)
+        {
+            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] 未対応フォーマット slot={slot}、vanilla 320 にフォールバック");
+            return null;
+        }
+
+        // LoadImage は target Texture2D のサイズを自動的にリサイズする。
+        // 作成時のサイズ・フォーマットは placeholder 扱い。
+        var tex = new Texture2D(2, 2, GraphicsFormat.R8G8B8A8_SRGB, 0, TextureCreationFlags.None);
+        bool ok;
+        try
+        {
+            ok = ImageConversion.LoadImage(tex, payload, markNonReadable: false);
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] LoadImage 例外 slot={slot}: {ex.Message}");
+            UnityEngine.Object.Destroy(tex);
+            return null;
+        }
+        if (!ok)
+        {
+            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] LoadImage 失敗 slot={slot}");
+            UnityEngine.Object.Destroy(tex);
+            return null;
+        }
+        // 破損 / 攻撃的 payload に備え、サイズを検証（正方形・範囲内）。
+        if (tex.width != tex.height || tex.width < SizeMin || tex.width > SizeMax)
+        {
+            PatchLogger.LogWarning($"[ChekiItemLoadHiResPatch] デコード後サイズ不正 slot={slot} {tex.width}x{tex.height}、スキップ");
+            UnityEngine.Object.Destroy(tex);
+            return null;
+        }
+        return tex;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
@@ -1,0 +1,269 @@
+using System.Collections;
+using BunnyGarden2FixMod.Utils;
+using GB.Save;
+using HarmonyLib;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// 最後に撮影した高解像度チェキ Texture2D を一時的に保持するサイドカー。
+///
+/// <para>
+/// 本体の保存形式 (<c>ChekiData.m_rawData = new byte[409600]</c>) は 320x320 固定のため、
+/// <see cref="Saves.m_cheki"/> は必ず 320x320 のまま維持する（互換維持の不変条件）。
+/// 高解像度版はこの静的ホルダーに一時保管し、直後に走る
+/// <see cref="GB.Game.GameData.SaveCheki"/> の Postfix（<see cref="ChekiSaveHiResPatch"/>）で
+/// ExSave に書き出される。
+/// </para>
+///
+/// <para>
+/// <b>鮮度チェック:</b> 連続撮影・シーン遷移でコルーチンが中断された場合に古い hi-res が
+/// 次スロットに誤って書き込まれたり、Destroy されず GPU リソースが漏れるのを防ぐため、
+/// <see cref="CapturedFrame"/> と現在フレーム差が <see cref="FreshnessFrameWindow"/> を超えた
+/// エントリは「古い」と見なして破棄する。
+/// </para>
+/// </summary>
+internal static class ChekiHiResSidecar
+{
+    /// <summary>
+    /// 撮影からどのくらいのフレーム数で使用（GameData.SaveCheki Postfix）が発生することを許容するか。
+    /// 通常は WaitForEndOfFrame 1 回 + UniTask.DelayFrame(1) なので 2〜3 フレームで消費される想定。
+    /// 10 フレーム（≒0.17 秒 @60fps）は、ユーザー操作（タップ→ダイアログ）より十分短く
+    /// 別スロットへの誤混入を物理的に不可能にする安全窓。
+    /// </summary>
+    public const int FreshnessFrameWindow = 10;
+
+    public static Texture2D LastCaptured;
+    public static int CapturedFrame = int.MinValue;
+    public static int CapturedSize;
+
+    public static bool IsFresh()
+    {
+        if (LastCaptured == null) return false;
+        return Time.frameCount - CapturedFrame <= FreshnessFrameWindow;
+    }
+
+    public static void Store(Texture2D tex, int size)
+    {
+        // 古い Texture2D が残っていれば破棄（漏れ防止）。
+        DestroyIfAny();
+        LastCaptured = tex;
+        CapturedSize = size;
+        CapturedFrame = Time.frameCount;
+    }
+
+    public static Texture2D TakeIfFresh(out int size)
+    {
+        size = 0;
+        if (!IsFresh())
+        {
+            DestroyIfAny();
+            return null;
+        }
+        Texture2D tex = LastCaptured;
+        size = CapturedSize;
+        LastCaptured = null;
+        CapturedFrame = int.MinValue;
+        CapturedSize = 0;
+        return tex;
+    }
+
+    public static void DestroyIfAny()
+    {
+        if (LastCaptured != null)
+        {
+            Object.Destroy(LastCaptured);
+            LastCaptured = null;
+        }
+        CapturedFrame = int.MinValue;
+        CapturedSize = 0;
+    }
+}
+
+/// <summary>
+/// <see cref="Saves.CaptureCheki"/>（IEnumerator コルーチン）を差し替えて、
+/// vanilla の 320x320 キャプチャに加えて高解像度版も別ホルダーに確保するパッチ。
+///
+/// <para>
+/// <b>互換維持の不変条件:</b> <c>Saves.m_cheki</c> は必ず 320x320 のままにする。
+/// ゲーム本体の <c>ChekiData.Set</c> が <c>tex.GetRawTextureData()</c> を呼び
+/// <c>m_rawData = new byte[409600]</c> (= 320*320*4) 固定バッファへ <c>Array.Copy</c> するため、
+/// サイズが変わると <c>ArgumentException</c> で進行停止する。
+/// </para>
+///
+/// <para>
+/// <b>設計:</b> Prefix で <c>__result</c> を独自 IEnumerator に差し替える。
+/// コンパイラ生成のステートマシン本体（<c>&lt;CaptureCheki&gt;d__N.MoveNext</c>）には触れない。
+/// 独自コルーチンでは:
+/// <list type="number">
+///   <item>vanilla 相当の 320x320 キャプチャを実施し <c>m_cheki</c> に格納</item>
+///   <item>同一のキャプチャ元テクスチャから、別 RT に Blit して高解像度 Texture2D を生成</item>
+///   <item>高解像度版を <see cref="ChekiHiResSidecar"/> に一時保管</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <see cref="Plugin.ConfigChekiHighResEnabled"/> が false のときは元処理をそのまま走らせる
+/// （Prefix が true を返す → vanilla が実行される）。
+/// </para>
+/// </summary>
+[HarmonyPatch(typeof(Saves), nameof(Saves.CaptureCheki))]
+public static class ChekiResolutionPatch
+{
+    private const int VanillaSize = 320;
+    private const int SizeLowerClamp = 64;
+    private const int SizeUpperClamp = 2048;
+
+    private static AccessTools.FieldRef<Saves, Texture2D> s_chekiRef;
+    private static AccessTools.FieldRef<Saves, Texture2D> s_captureRef;
+    private static AccessTools.FieldRef<Saves, RenderTexture> s_rtRef;
+    private static bool s_loggedApplied;
+
+    static bool Prepare()
+    {
+        // FieldRefAccess は static initializer で例外を投げる可能性があるので Prepare で防御。
+        // フィールドが存在しないゲームバージョンでは MOD ロードを壊さずこのパッチだけ無効化する。
+        try
+        {
+            s_chekiRef = AccessTools.FieldRefAccess<Saves, Texture2D>("m_cheki");
+            s_captureRef = AccessTools.FieldRefAccess<Saves, Texture2D>("m_capture");
+            s_rtRef = AccessTools.FieldRefAccess<Saves, RenderTexture>("m_renderTexture");
+        }
+        catch (System.Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiResolutionPatch] FieldRef 初期化失敗、パッチ無効化: {ex.Message}");
+            return false;
+        }
+        PatchLogger.LogInfo("[ChekiResolutionPatch] Saves.CaptureCheki をパッチしました（デュアル解像度キャプチャ）");
+        return true;
+    }
+
+    private static bool Prefix(Saves __instance, ref IEnumerator __result)
+    {
+        if (!Plugin.ConfigChekiHighResEnabled.Value)
+        {
+            // 既定 OFF: vanilla 挙動。ホルダーは空に戻しておく（古い hi-res が残っていると誤使用の元）。
+            ChekiHiResSidecar.DestroyIfAny();
+            return true;
+        }
+        __result = CaptureDualRes(__instance);
+        return false;
+    }
+
+    private static IEnumerator CaptureDualRes(Saves self)
+    {
+        int hiSize = Mathf.Clamp(Plugin.ConfigChekiSize.Value, SizeLowerClamp, SizeUpperClamp);
+
+        if (!s_loggedApplied)
+        {
+            PatchLogger.LogInfo($"[ChekiResolutionPatch] 適用: vanilla 320 + hi-res {hiSize}x{hiSize}");
+            s_loggedApplied = true;
+        }
+
+        // m_cheki を 320x320 で再生成（互換維持の不変条件）。
+        if (s_chekiRef(self) != null)
+        {
+            Object.Destroy(s_chekiRef(self));
+            s_chekiRef(self) = null;
+        }
+        s_chekiRef(self) = new Texture2D(
+            VanillaSize, VanillaSize,
+            GraphicsFormat.R8G8B8A8_SRGB,
+            0,
+            TextureCreationFlags.None);
+
+        // 直前の m_capture は解放。
+        if (s_captureRef(self) != null)
+        {
+            Object.Destroy(s_captureRef(self));
+            s_captureRef(self) = null;
+        }
+
+        // 既存 hi-res sidecar はここで解放（使用されずに再撮影されたケースに備える）。
+        ChekiHiResSidecar.DestroyIfAny();
+
+        yield return new WaitForEndOfFrame();
+
+        // 画面の実アスペクト比でキャプチャを取得。
+        s_captureRef(self) = ScreenCapture.CaptureScreenshotAsTexture();
+        var capture = s_captureRef(self);
+        float captureAspect = (float)capture.width / Mathf.Max(1, capture.height);
+
+        // --- vanilla 側: 568x320 RT に Blit → 320x320 中央クロップで m_cheki に格納 ---
+        int vanillaRtWidth = VanillaSize * 16 / 9;
+        int vanillaRtHeight = VanillaSize;
+        var rtVanilla = s_rtRef(self);
+        if (rtVanilla == null || rtVanilla.width != vanillaRtWidth || rtVanilla.height != vanillaRtHeight)
+        {
+            if (rtVanilla != null)
+            {
+                rtVanilla.Release();
+                Object.Destroy(rtVanilla);
+            }
+            s_rtRef(self) = new RenderTexture(
+                vanillaRtWidth, vanillaRtHeight,
+                24,
+                GraphicsFormat.R8G8B8A8_UNorm);
+        }
+        Graphics.Blit(capture, s_rtRef(self));
+
+        var prevActive = RenderTexture.active;
+        try
+        {
+            RenderTexture.active = s_rtRef(self);
+            int srcX = Mathf.Max(0, (vanillaRtWidth - VanillaSize) / 2);
+            s_chekiRef(self).ReadPixels(
+                new Rect(srcX, 0f, VanillaSize, VanillaSize),
+                0, 0,
+                recalculateMipMaps: false);
+            s_chekiRef(self).Apply();
+        }
+        finally
+        {
+            RenderTexture.active = prevActive;
+        }
+
+        // --- 高解像度側: 専用 RT を確保し、そこから正方形クロップ ---
+        int hiRtWidth = Mathf.Max(hiSize, Mathf.RoundToInt(hiSize * captureAspect));
+        int hiRtHeight = hiSize;
+
+        // vanilla RT とは別インスタンス。毎回作って毎回破棄（撮影頻度は低いのでコスト許容）。
+        RenderTexture hiRT = new RenderTexture(hiRtWidth, hiRtHeight, 24, GraphicsFormat.R8G8B8A8_UNorm);
+        Texture2D hiTex = null;
+        try
+        {
+            Graphics.Blit(capture, hiRT);
+            hiTex = new Texture2D(hiSize, hiSize, GraphicsFormat.R8G8B8A8_SRGB, 0, TextureCreationFlags.None);
+
+            var prev = RenderTexture.active;
+            try
+            {
+                RenderTexture.active = hiRT;
+                int hiSrcX = Mathf.Max(0, (hiRtWidth - hiSize) / 2);
+                hiTex.ReadPixels(
+                    new Rect(hiSrcX, 0f, hiSize, hiSize),
+                    0, 0,
+                    recalculateMipMaps: false);
+                hiTex.Apply();
+            }
+            finally
+            {
+                RenderTexture.active = prev;
+            }
+
+            ChekiHiResSidecar.Store(hiTex, hiSize);
+            hiTex = null; // ownership transferred to sidecar
+        }
+        finally
+        {
+            if (hiTex != null)
+            {
+                Object.Destroy(hiTex);
+            }
+            hiRT.Release();
+            Object.Destroy(hiRT);
+        }
+    }
+}

--- a/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
@@ -1,0 +1,140 @@
+using System;
+using BunnyGarden2FixMod.ExSave;
+using BunnyGarden2FixMod.Utils;
+using GB.Game;
+using HarmonyLib;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// <see cref="GameData.SaveCheki"/> の Postfix で、
+/// <see cref="ChekiHiResSidecar"/> に保管された高解像度 Texture2D を ExSave に書き込むパッチ。
+///
+/// <para>
+/// フロー:
+/// <list type="number">
+///   <item><c>Saves.CaptureCheki</c>（<see cref="ChekiResolutionPatch"/> で差し替え）が sidecar に hi-res を保存</item>
+///   <item><c>GBSystem.SaveCheki</c> が <c>UniTask.DelayFrame(1)</c> 後に <c>m_gameData.SaveCheki(slot, tex, ...)</c> を呼ぶ</item>
+///   <item>vanilla の <c>ChekiData.Set</c> で 320x320 raw bytes が <c>m_rawData</c> にコピーされる</item>
+///   <item>↑の直後、この Postfix が走り、sidecar の hi-res Texture2D を ExSave へ格納</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <b>ペイロード形式:</b> PNG または JPG エンコード済みバイト列。読み込み側は magic byte で自動判別する。
+/// </para>
+///
+/// <para>
+/// 鮮度チェック（<see cref="ChekiHiResSidecar.IsFresh"/>）で古い sidecar は破棄。
+/// Config OFF のときや hi-res sidecar が無いとき（vanilla 経路）は何もしない。
+/// </para>
+/// </summary>
+[HarmonyPatch(typeof(GameData), nameof(GameData.SaveCheki))]
+public static class ChekiSaveHiResPatch
+{
+    /// <summary>
+    /// チェキスロットの想定範囲（ゲーム本体で <c>new ChekiData[12]</c>）。
+    ///
+    /// <para>
+    /// <b>注意:</b> この値はゲーム本体 <c>GameData.m_chekiData</c> の配列長と一致させる必要がある。
+    /// ゲームアップデートで配列長が変わった場合はこの定数も合わせて更新すること。
+    /// 動的取得（リフレクション等）は実装スコープ外のため、ハードコード値を採用している。
+    /// </para>
+    /// </summary>
+    public const int MaxSlot = 12;
+
+    public static string KeyFor(int slot) => $"cheki.hires.{slot}";
+
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ChekiSaveHiResPatch] GameData.SaveCheki をパッチしました（ExSave 書込）");
+        return true;
+    }
+
+    private static void Postfix(int slot)
+    {
+        if (!Plugin.ConfigChekiHighResEnabled.Value)
+        {
+            // Config OFF: sidecar は使わない。残留があれば破棄。
+            ChekiHiResSidecar.DestroyIfAny();
+            return;
+        }
+
+        // slot 範囲外は受け付けない（異常系防御）。
+        if (slot < 0 || slot >= MaxSlot)
+        {
+            PatchLogger.LogWarning($"[ChekiSaveHiResPatch] slot 範囲外 slot={slot}、hi-res 保存をスキップ");
+            ChekiHiResSidecar.DestroyIfAny();
+            return;
+        }
+
+        Texture2D hiTex = ChekiHiResSidecar.TakeIfFresh(out int size);
+        if (hiTex == null)
+        {
+            // このスロットには hi-res が無い（Config を途中 ON にした直後など）。
+            // vanilla 320x320 のみが保存される経路。表示側はそちらにフォールバック。
+            return;
+        }
+
+        try
+        {
+            byte[] payload = EncodePayload(hiTex);
+            if (payload == null)
+            {
+                PatchLogger.LogWarning($"[ChekiSaveHiResPatch] エンコード失敗 slot={slot}、スキップ");
+                return;
+            }
+
+            string key = KeyFor(slot);
+            ExSaveStore.CurrentSession.Set(key, payload);
+            PatchLogger.LogInfo($"[ChekiSaveHiResPatch] ExSave に格納: {key} ({size}x{size}, {Plugin.ConfigChekiFormat.Value}, {payload.Length} bytes)");
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiSaveHiResPatch] ExSave 書込失敗 slot={slot}: {ex.Message}");
+        }
+        finally
+        {
+            // Texture2D は役目を終えたので確実に破棄。
+            UnityEngine.Object.Destroy(hiTex);
+        }
+    }
+
+    /// <summary>
+    /// 設定された <see cref="Plugin.ConfigChekiFormat"/> に応じて Texture2D をバイト列にエンコードする。
+    ///
+    /// <para>
+    /// 形式:
+    /// <list type="bullet">
+    ///   <item><b>PNG</b>: <c>ImageConversion.EncodeToPNG</c> 出力バイト列。先頭 4B が PNG シグネチャ <c>89 50 4E 47</c></item>
+    ///   <item><b>JPG</b>: <c>ImageConversion.EncodeToJPG</c> 出力バイト列。先頭 3B が <c>FF D8 FF</c></item>
+    /// </list>
+    /// 読み込み側は magic byte で自動判別する。
+    /// </para>
+    /// </summary>
+    private static byte[] EncodePayload(Texture2D tex)
+    {
+        var format = Plugin.ConfigChekiFormat.Value;
+        try
+        {
+            switch (format)
+            {
+                case ChekiImageFormat.JPG:
+                {
+                    int quality = Mathf.Clamp(Plugin.ConfigChekiJpgQuality.Value, 1, 100);
+                    return ImageConversion.EncodeToJPG(tex, quality);
+                }
+
+                case ChekiImageFormat.PNG:
+                default:
+                    return ImageConversion.EncodeToPNG(tex);
+            }
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiSaveHiResPatch] {format} エンコードで例外: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
@@ -33,26 +33,39 @@ namespace BunnyGarden2FixMod.Patches;
 [HarmonyPatch(typeof(GameData), nameof(GameData.SaveCheki))]
 public static class ChekiSaveHiResPatch
 {
-    /// <summary>
-    /// チェキスロットの想定範囲（ゲーム本体で <c>new ChekiData[12]</c>）。
-    ///
-    /// <para>
-    /// <b>注意:</b> この値はゲーム本体 <c>GameData.m_chekiData</c> の配列長と一致させる必要がある。
-    /// ゲームアップデートで配列長が変わった場合はこの定数も合わせて更新すること。
-    /// 動的取得（リフレクション等）は実装スコープ外のため、ハードコード値を採用している。
-    /// </para>
-    /// </summary>
-    public const int MaxSlot = 12;
+    private static AccessTools.FieldRef<GameData, GameData.ChekiData[]> s_chekiDataRef;
 
     public static string KeyFor(int slot) => $"cheki.hires.{slot}";
 
+    /// <summary>
+    /// 指定された <paramref name="gameData"/> のチェキスロット数を返す。
+    /// <c>GameData.m_chekiData</c>（protected）の配列長を FieldRef 経由で取得するため、
+    /// ゲーム本体が将来スロット数を変更してもコード修正なしに追従する。
+    /// FieldRef 未初期化・インスタンス null・配列 null の場合は -1 を返す。
+    /// </summary>
+    public static int GetSlotCount(GameData gameData)
+    {
+        if (gameData == null || s_chekiDataRef == null) return -1;
+        var arr = s_chekiDataRef(gameData);
+        return arr?.Length ?? -1;
+    }
+
     static bool Prepare()
     {
+        try
+        {
+            s_chekiDataRef = AccessTools.FieldRefAccess<GameData, GameData.ChekiData[]>("m_chekiData");
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ChekiSaveHiResPatch] FieldRef 初期化失敗、パッチ無効化: {ex.Message}");
+            return false;
+        }
         PatchLogger.LogInfo("[ChekiSaveHiResPatch] GameData.SaveCheki をパッチしました（ExSave 書込）");
         return true;
     }
 
-    private static void Postfix(int slot)
+    private static void Postfix(GameData __instance, int slot)
     {
         if (!Plugin.ConfigChekiHighResEnabled.Value)
         {
@@ -61,10 +74,17 @@ public static class ChekiSaveHiResPatch
             return;
         }
 
-        // slot 範囲外は受け付けない（異常系防御）。
-        if (slot < 0 || slot >= MaxSlot)
+        // slot 範囲外は受け付けない（異常系防御）。配列長は本体から動的取得。
+        int slotCount = GetSlotCount(__instance);
+        if (slotCount < 0)
         {
-            PatchLogger.LogWarning($"[ChekiSaveHiResPatch] slot 範囲外 slot={slot}、hi-res 保存をスキップ");
+            PatchLogger.LogWarning($"[ChekiSaveHiResPatch] スロット数取得失敗、hi-res 保存をスキップ");
+            ChekiHiResSidecar.DestroyIfAny();
+            return;
+        }
+        if (slot < 0 || slot >= slotCount)
+        {
+            PatchLogger.LogWarning($"[ChekiSaveHiResPatch] slot 範囲外 slot={slot} max={slotCount}、hi-res 保存をスキップ");
             ChekiHiResSidecar.DestroyIfAny();
             return;
         }

--- a/BunnyGarden2FixMod/Patches/EndingChekiSlideshowPatch.cs
+++ b/BunnyGarden2FixMod/Patches/EndingChekiSlideshowPatch.cs
@@ -1,3 +1,4 @@
+using BunnyGarden2FixMod.ExSave;
 using BunnyGarden2FixMod.Utils;
 using GB;
 using GB.Game;
@@ -163,11 +164,26 @@ public sealed class ChekiSlideshowBehaviour : MonoBehaviour
                 byte[] rawData = chekiData.GetRawData();
                 if (rawData == null || rawData.Length != ChekiTexWidth * ChekiTexHeight * 4) continue;
 
-                // 写真テクスチャ → Sprite
-                var tex = new Texture2D(ChekiTexWidth, ChekiTexHeight, TextureFormat.RGBA32, false);
-                tex.LoadRawTextureData(rawData);
-                tex.Apply();
-                var photoSprite = Sprite.Create(tex, new Rect(0, 0, ChekiTexWidth, ChekiTexHeight), new Vector2(0.5f, 0.5f));
+                // 写真テクスチャ → Sprite。ExSave に hi-res があればそちらを優先し、
+                // 失敗・未設定時は vanilla 320 の raw データから構築する。
+                Texture2D tex = null;
+                if (Plugin.ConfigChekiHighResEnabled.Value)
+                {
+                    string key = ChekiSaveHiResPatch.KeyFor(slot);
+                    if (ExSaveStore.CurrentSession.TryGet(key, out byte[] payload)
+                        && payload != null && payload.Length >= 4)
+                    {
+                        tex = ChekiItemLoadHiResPatch.DecodePayload(
+                            payload, slot, "[EndingChekiSlideshow]");
+                    }
+                }
+                if (tex == null)
+                {
+                    tex = new Texture2D(ChekiTexWidth, ChekiTexHeight, TextureFormat.RGBA32, false);
+                    tex.LoadRawTextureData(rawData);
+                    tex.Apply();
+                }
+                var photoSprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f));
 
                 // キャスト情報
                 CharID mainCast = chekiData.GetMainCast();

--- a/BunnyGarden2FixMod/Patches/ExSaveLifecyclePatch.cs
+++ b/BunnyGarden2FixMod/Patches/ExSaveLifecyclePatch.cs
@@ -1,0 +1,161 @@
+using System;
+using BunnyGarden2FixMod.ExSave;
+using BunnyGarden2FixMod.Utils;
+using Cysharp.Threading.Tasks;
+using GB.Save;
+using HarmonyLib;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// MOD 独自サイドカー (<c>.exmod</c>) のライフサイクルを <see cref="Saves"/> のロード／保存に同期させるパッチ群。
+///
+/// <list type="bullet">
+///   <item>
+///     <term>Load</term>
+///     <description>
+///     <c>Saves.Load()</c> は sync なので Postfix で主セーブパスを解決して
+///     <see cref="ExSaveStore.LoadFromPath"/> を呼ぶ。その後 <see cref="ExSaveStore.ResetSession"/>
+///     でセッション状態を初期化する（AllSlots は保持）。
+///     </description>
+///   </item>
+///   <item>
+///     <term>Save</term>
+///     <description>
+///     <c>Saves.Save()</c> は <c>async UniTask</c>。Harmony は async メソッドの外側 stub にのみ当てられ、
+///     ステートマシン本体（MoveNext）は触れない。Postfix で <c>ref UniTask __result</c> を
+///     wrapper task に差し替え、元 task を await した<b>後</b>に ExSave を保存する逐次化パターンを使う。
+///     <para>
+///     <see cref="ExSaveStore.CurrentSaveSlot"/> が 0 以上の場合、await 前（= 主セーブ書き出し前）に
+///     同期で <see cref="ExSaveStore.CommitSession"/> を実行して CurrentSession の内容を AllSlots に反映させる
+///     （await 中に CurrentSession が変更されてもコピー済みのため破損しない。
+///     <c>UpdateSaveSlot</c> を経由しない <c>Save()</c> 直接呼び出し経路の救済も兼ねる）。
+///     </para>
+///     </description>
+///   </item>
+///   <item>
+///     <term>CreateNewData</term>
+///     <description>
+///     <c>Saves.CreateNewData()</c> Postfix で全状態リセット（AllSlots・CurrentSession・CurrentSaveSlot）。
+///     </description>
+///   </item>
+/// </list>
+///
+/// <para>
+/// 本パッチは <see cref="Plugin.ConfigChekiHighResEnabled"/> の値に関係なく常に適用される
+/// （ExSave 基盤は汎用であり、将来の機能追加でも使える共通配線）。
+/// </para>
+/// </summary>
+internal static class ExSaveLifecyclePatch
+{
+}
+
+/// <summary>
+/// <c>Saves.Load()</c> Postfix: 主セーブ読み込み完了後にサイドカーを読み込む。
+/// セッション状態は <see cref="ExSaveStore.ResetSession"/> でリセットする（AllSlots は保持）。
+/// </summary>
+[HarmonyPatch(typeof(Saves), nameof(Saves.Load))]
+public static class ExSaveOnLoadPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ExSaveOnLoadPatch] Saves.Load をパッチしました（サイドカー読込）");
+        return true;
+    }
+
+    private static void Postfix(Saves __instance)
+    {
+        string path = ExSaveStore.TryResolveMainPath(__instance);
+        if (string.IsNullOrEmpty(path))
+        {
+            // Paths 未解決（新規ゲームなど）。empty state で続行。
+            ExSaveStore.Reset();
+            return;
+        }
+        // AllSlots をファイルから読み込み、セッション状態は初期化する
+        ExSaveStore.LoadFromPath(path);
+        ExSaveStore.ResetSession();
+    }
+}
+
+/// <summary>
+/// <c>Saves.Save()</c> Postfix: 本体保存 UniTask を wrap して完了後にサイドカーを保存する。
+/// <see cref="ExSaveStore.CurrentSaveSlot"/> が 0 以上の場合は、await 前（同期フェーズ）に
+/// <see cref="ExSaveStore.CommitSession"/> を実行してから wrap に入る
+/// （await 中の CurrentSession 変更による破損防止。<c>UpdateSaveSlot</c> 非経由パスの救済も兼ねる）。
+/// </summary>
+[HarmonyPatch(typeof(Saves), nameof(Saves.Save))]
+public static class ExSaveOnSavePatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ExSaveOnSavePatch] Saves.Save をパッチしました（サイドカー保存 wrap）");
+        return true;
+    }
+
+    private static void Postfix(Saves __instance, ref UniTask __result)
+    {
+        // await 前（= 主セーブ書き出し開始前）に同期でコミットしておく。
+        // await 中に他スレッド / 別 UI 操作で CurrentSession が更新されても
+        // AllSlots へのコピーは既に済んでいるため破損しない。
+        if (ExSaveStore.CurrentSaveSlot >= 0)
+        {
+            ExSaveStore.CommitSession(ExSaveStore.CurrentSaveSlot);
+            PatchLogger.LogInfo($"[ExSave] CommitSession(slot={ExSaveStore.CurrentSaveSlot}) 実行（await 前に同期実行）");
+        }
+        else
+        {
+            PatchLogger.LogInfo("[ExSave] CurrentSaveSlot=-1 のため CommitSession スキップ（既存 AllSlots をそのまま書き出し）");
+        }
+
+        // async メソッドの Postfix で __result を差し替えるケースは、
+        // 元タスク(orig)を WrapAndPersist の中で 1 度だけ await する逐次パターンに限定する。
+        // orig を外部で別に await すると二重消費になるため、この Postfix の外では orig を参照しないこと。
+        // Preserve() は UniTask 内部を AsyncLazy 的に保持して完了状態の再参照を許容する防御措置。
+        var orig = __result.Preserve();
+        __result = WrapAndPersist(orig, __instance);
+    }
+
+    private static async UniTask WrapAndPersist(UniTask originalSave, Saves saves)
+    {
+        // 本体保存を先に完遂させる。本体側で例外が出た場合はそのまま伝播させる（本体の挙動を変えない）。
+        await originalSave;
+
+        // 本体保存に成功した後だけサイドカーを書き出す。
+        // ここでの例外は本体保存結果に影響させず、ログにとどめる。
+        try
+        {
+            string path = ExSaveStore.CurrentMainPath ?? ExSaveStore.TryResolveMainPath(saves);
+            if (string.IsNullOrEmpty(path))
+            {
+                PatchLogger.LogWarning("[ExSave] 主セーブパス未解決のためサイドカー保存をスキップ");
+                return;
+            }
+
+            await ExSaveStore.SaveToPathAsync(path);
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[ExSave] サイドカー保存中に例外: {ex.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// <c>Saves.CreateNewData()</c> Postfix: 新規ゲーム作成時に全状態をリセットする。
+/// </summary>
+[HarmonyPatch(typeof(Saves), nameof(Saves.CreateNewData))]
+public static class ExSaveOnCreateNewDataPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ExSaveOnCreateNewDataPatch] Saves.CreateNewData をパッチしました（全状態リセット）");
+        return true;
+    }
+
+    private static void Postfix()
+    {
+        ExSaveStore.Reset();
+        PatchLogger.LogInfo("[ExSaveOnCreateNewDataPatch] 新規ゲーム: ExSave 全状態をリセット");
+    }
+}

--- a/BunnyGarden2FixMod/Patches/ExSaveSaveSlotTrackingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ExSaveSaveSlotTrackingPatch.cs
@@ -1,0 +1,190 @@
+using System;
+using BunnyGarden2FixMod.ExSave;
+using BunnyGarden2FixMod.Utils;
+using GB;
+using GB.Extra;
+using GB.Game;
+using GB.Save;
+using HarmonyLib;
+
+namespace BunnyGarden2FixMod.Patches;
+
+// =====================================================
+// アルバム閲覧の一方向 CopyFrom を識別するフラグ
+// =====================================================
+/// <summary>
+/// <see cref="ExtraChekiSelector.updateConfirm"/> の Prefix で true にセットされ、
+/// 直後の <see cref="GameData.CopyFrom"/> Postfix で消費して false に戻す極短命フラグ。
+/// Unity メインスレッド専用（競合リスクなし）。
+/// </summary>
+internal static class AlbumViewGate
+{
+    public static bool InProgress;
+}
+
+// =====================================================
+// ExtraChekiSelector.updateConfirm Prefix / Finalizer
+// =====================================================
+/// <summary>
+/// <c>ExtraChekiSelector.updateConfirm</c> の Prefix で <see cref="AlbumViewGate.InProgress"/> を
+/// true にセットする。このフラグにより直後の <see cref="GameData.CopyFrom"/> がアルバム閲覧起点か
+/// 通常ロード起点かを区別できる。
+///
+/// <para>
+/// Finalizer は <c>updateConfirm</c> が例外や途中 return で終了した場合でも
+/// <see cref="AlbumViewGate.InProgress"/> を強制クリアする二重防御。
+/// Finalizer は例外時も必ず実行されることが Harmony で保証されている。
+/// </para>
+/// </summary>
+[HarmonyPatch(typeof(ExtraChekiSelector), "updateConfirm")]
+public static class ExtraChekiSelectorViewPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[ExtraChekiSelectorViewPatch] 適用");
+        return true;
+    }
+
+    static void Prefix() => AlbumViewGate.InProgress = true;
+
+    // updateConfirm の実行が例外や途中 return で終わっても、AlbumViewGate が
+    // 残留すると次回の通常 CopyFrom が誤って閲覧モード扱いになる。
+    // Finalizer は例外時も必ず実行されるため、二重防御として強制クリアする。
+    static void Finalizer()
+    {
+        if (AlbumViewGate.InProgress)
+        {
+            PatchLogger.LogWarning("[ExtraChekiSelectorViewPatch] updateConfirm 終了時に AlbumViewGate 残留、強制クリア");
+            AlbumViewGate.InProgress = false;
+        }
+    }
+}
+
+// =====================================================
+// GameData.CopyFrom(GameData) Postfix
+// =====================================================
+/// <summary>
+/// <see cref="GameData.CopyFrom"/> の Postfix でセーブスロット追跡を行う。
+///
+/// <list type="bullet">
+///   <item>
+///     <term>セーブ方向スキップ</term>
+///     <description><c>__instance is SavedGameData</c> の場合はスキップ（UpdateSaveSlot 経由の逆方向）</description>
+///   </item>
+///   <item>
+///     <term>アルバム閲覧</term>
+///     <description>
+///     <see cref="AlbumViewGate.InProgress"/> が true の場合は閲覧モード。
+///     <see cref="ExSaveStore.LoadSession"/> で M のデータを CurrentSession にコピーし、
+///     <see cref="ExSaveStore.CurrentSaveSlot"/> = -1 をセットしてセーブ汚染を防ぐ。
+///     </description>
+///   </item>
+///   <item>
+///     <term>通常ロード</term>
+///     <description>
+///     <see cref="ExSaveStore.LoadSession"/> を呼び出して CurrentSession を更新し、
+///     CurrentSaveSlot = N をセットする。
+///     </description>
+///   </item>
+/// </list>
+/// </summary>
+[HarmonyPatch(typeof(GameData), nameof(GameData.CopyFrom), new[] { typeof(GameData) })]
+public static class GameDataCopyFromPatch
+{
+    private static AccessTools.FieldRef<SaveData, SavedGameData[]> s_savedSlotsRef;
+
+    static bool Prepare()
+    {
+        try
+        {
+            s_savedSlotsRef = AccessTools.FieldRefAccess<SaveData, SavedGameData[]>("m_savedGameData");
+            PatchLogger.LogInfo("[GameDataCopyFromPatch] 適用");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError($"[GameDataCopyFromPatch] FieldRef 初期化失敗、パッチ無効化: {ex.Message}");
+            return false;
+        }
+    }
+
+    static void Postfix(GameData __instance, GameData __0)
+    {
+        // フラグは必ず消費する（Prefix が走ったが Postfix が途中で例外になっても残留しないよう）
+        bool albumView = AlbumViewGate.InProgress;
+        AlbumViewGate.InProgress = false;
+
+        // セーブ方向（SavedGameData.UpdateData → CopyFrom）はスキップ
+        if (__instance is SavedGameData) return;
+
+        // rhs が SavedGameData でない場合はゲーム内の別 CopyFrom なのでスキップ
+        if (!(__0 is SavedGameData target))
+        {
+            // アルバム閲覧フラグが立っていたが rhs が SavedGameData でない場合のフォールバック
+            if (albumView)
+            {
+                PatchLogger.LogInfo("[GameDataCopyFromPatch] アルバム閲覧フラグあり、rhs が SavedGameData でないためスキップ");
+            }
+            return;
+        }
+
+        // m_savedGameData[] から target の index を逆引きする
+        int slot = FindIndex(target);
+        if (slot < 0)
+        {
+            PatchLogger.LogWarning("[GameDataCopyFromPatch] SavedGameData[] 逆引き失敗、セッション不変");
+            return;
+        }
+
+        if (albumView)
+        {
+            // アルバム閲覧モード: CurrentSession は M の内容を持つが、保存先スロットは不明マーカー
+            ExSaveStore.LoadSession(slot);
+            ExSaveStore.CurrentSaveSlot = -1;
+            PatchLogger.LogInfo($"[GameDataCopyFromPatch] アルバム閲覧 slot={slot}（CurrentSaveSlot=-1）");
+        }
+        else
+        {
+            // 通常ロード
+            ExSaveStore.LoadSession(slot);
+            PatchLogger.LogInfo($"[GameDataCopyFromPatch] 通常ロード slot={slot}");
+        }
+    }
+
+    private static int FindIndex(SavedGameData target)
+    {
+        var sd = GBSystem.Instance?.RefSaveData();
+        if (sd == null) return -1;
+        var slots = s_savedSlotsRef(sd);
+        if (slots == null) return -1;
+        for (int i = 0; i < slots.Length; i++)
+        {
+            if (ReferenceEquals(slots[i], target)) return i;
+        }
+        return -1;
+    }
+}
+
+// =====================================================
+// SaveData.UpdateSaveSlot(int slot) Postfix
+// =====================================================
+/// <summary>
+/// <c>SaveData.UpdateSaveSlot(int slot)</c> の Postfix で <see cref="ExSaveStore.CurrentSaveSlot"/> を更新する。
+/// <c>CommitSession</c> 自体は <c>Saves.Save</c> Postfix が担当する（全経路共通）。
+/// Postfix 採用により、<c>UpdateSaveSlot</c> が成功した後にのみ CurrentSaveSlot を更新する意味論となる。
+/// </summary>
+[HarmonyPatch(typeof(SaveData), nameof(SaveData.UpdateSaveSlot))]
+public static class SaveDataUpdateSlotPatch
+{
+    static bool Prepare()
+    {
+        PatchLogger.LogInfo("[SaveDataUpdateSlotPatch] 適用");
+        return true;
+    }
+
+    static void Postfix(int slot)
+    {
+        ExSaveStore.CurrentSaveSlot = slot;
+        PatchLogger.LogInfo($"[SaveDataUpdateSlotPatch] CurrentSaveSlot={slot}");
+    }
+}

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -25,6 +25,15 @@ public enum AntiAliasingType
     MSAA8x,
 }
 
+/// <summary>チェキ高解像度版を ExSave に保存する際の画像フォーマット。</summary>
+public enum ChekiImageFormat
+{
+    /// <summary>PNG 無劣化圧縮。サイズ 1/5〜1/20・エンコード 50〜200ms/枚</summary>
+    PNG,
+    /// <summary>JPG 劣化圧縮。サイズ 1/20〜1/50・エンコード 30〜100ms/枚</summary>
+    JPG,
+}
+
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
 public class Plugin : BaseUnityPlugin
 {
@@ -41,6 +50,10 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigGambleAlwaysWinEnabled;
     public static ConfigEntry<bool> ConfigDisableStockings;
     public static ConfigEntry<bool> ConfigContinueVoiceOnTap;
+    public static ConfigEntry<bool> ConfigChekiHighResEnabled;
+    public static ConfigEntry<int> ConfigChekiSize;
+    public static ConfigEntry<ChekiImageFormat> ConfigChekiFormat;
+    public static ConfigEntry<int> ConfigChekiJpgQuality;
     public static ConfigEntry<bool> ConfigEndingChekiSlideshow;
     public static ConfigEntry<bool> ConfigCastOrderEnabled;
 
@@ -115,6 +128,42 @@ public class Plugin : BaseUnityPlugin
             false,
             "true にすると会話送り（タップ／オート／スキップ）時にボイスが途中停止せず、\n" +
             "次の台詞のボイス再生で自然に上書きされるか、ボイスが最後まで再生されるようになります。");
+
+        ConfigChekiHighResEnabled = Config.Bind(
+            "Cheki",
+            "HighResEnabled",
+            false,
+            "true にするとチェキ（撮影写真）の保存解像度を Size で指定した値に変更します。\n" +
+            "false の場合は本体既定（320x320）のままです。\n" +
+            "互換性: 本体セーブには常に 320x320 版も保存されるため、MOD を外しても主セーブは破損しません。\n" +
+            "高解像度版は MOD 独自のサイドカーファイル（主セーブ + .exmod）に格納されます。\n" +
+            "スロット対応: セーブスロット単位で高解像度データを分離管理します。\n" +
+            "  別スロットに切り替えた際も各スロットの高解像度チェキが正しく表示されます。\n" +
+            "副作用: 高解像度化でメモリ／セーブサイズが増加します（1024 時: 約 48MB/12 枚）。");
+
+        ConfigChekiSize = Config.Bind(
+            "Cheki",
+            "Size",
+            1024,
+            "チェキ画像の正方形サイズ（ピクセル）。64〜2048 にクランプされます。既定 1024。\n" +
+            "HighResEnabled が false の場合は無視されます（本体既定の 320 が使用されます）。\n" +
+            "PNG で実測 1〜5MB/枚 程度に収まります。");
+
+        ConfigChekiFormat = Config.Bind(
+            "Cheki",
+            "ImageFormat",
+            ChekiImageFormat.PNG,
+            "ExSave に格納する画像フォーマット。PNG / JPG。既定 PNG。\n" +
+            "  PNG : 無劣化圧縮。サイズ 1/5〜1/20・エンコード 50〜200ms/枚。既定\n" +
+            "  JPG : 劣化圧縮。サイズ 1/20〜1/50・エンコード 30〜100ms/枚\n" +
+            "エンコードはシャッター時に 1 度のみ走ります。\n" +
+            "読み込みは magic byte による自動判別です。");
+
+        ConfigChekiJpgQuality = Config.Bind(
+            "Cheki",
+            "JpgQuality",
+            90,
+            "ImageFormat=JPG のときの品質（1〜100）。既定 90。値が小さいほどサイズは小さく画質は粗くなります。");
 
         ConfigEndingChekiSlideshow = Config.Bind(
             "Ending",


### PR DESCRIPTION
## 概要
ポラロイド写真ミニゲーム「チェキ」の解像度を設定可能（既定 1024x1024）にし、
高解像度版を MOD 独自のサイドカーファイル（`.exmod`）に保存するようにします。
本体セーブには従来通り 320x320 版を書き込み続けるため、MOD を外しても
主セーブは破損しません。

サイドカーは MessagePack + LZ4BlockArray 形式（ゲーム本体と同一オプション）で、
セーブスロット単位の階層構造で分離管理します。

## 主な変更点

### MOD 用サイドカーセーブ基盤 (`ExSave/`)
- `ExSaveData` / `ExSaveSlotData` を MessagePack POCO 化。`.exmod` に永続化
- `ExSaveStore` が `AllSlots` / `CurrentSession` / `CurrentSaveSlot` を一元管理
- `ExSaveLifecyclePatch` で `Saves.Load` / `Save` / `CreateNewData` に同期
- `ExSaveSaveSlotTrackingPatch` で `GameData.CopyFrom` を監視し、
  通常ロード・アルバム閲覧（`ExtraChekiSelector`）を識別してスロット汚染を防止

### チェキ高解像度化 (`Patches/Cheki*.cs` + `Plugin.cs`)
- `ChekiResolutionPatch`: `Saves.CaptureCheki` の IEnumerator を差し替え、
  vanilla 320（本体互換維持）と任意サイズ hi-res をフレーム鮮度付き sidecar に両取り
- `ChekiSaveHiResPatch`: `GameData.SaveCheki` Postfix で hi-res を ExSave に格納（PNG / JPG）
- `ChekiItemLoadHiResPatch`: `ChekiItem.SetupCheki` Postfix で ExSave の hi-res に差し替え。
  magic byte 自動判別（未対応なら vanilla 320 にフォールバック）
- `Plugin.cs`: Cheki 用 Config 4 件追加（`HighResEnabled` / `Size` / `ImageFormat` / `JpgQuality`）

### 依存
- MessagePack 系 DLL (`MessagePack.dll` / `MessagePack.Annotations.dll`) への参照を追加
  （ゲーム本体同梱のものを使用、`<Private>false</Private>` で配布 ZIP に含めない）
- UniTask.dll 参照追加

## 技術的な補足

### セーブスロット分離の設計
本体の `SaveData.m_savedGameData[9]` 構造を MOD 側でも模倣:
- `AllSlots`: 永続化全体（`.exmod` 内容に対応）
- `CurrentSession`: 現在プレイ中の作業セット（本体 `currentGameData` に対応）
- `CurrentSaveSlot`: ロード/セーブ先スロット。`-1` はセーブ不可マーカー（アルバム閲覧時）

`Saves.Save` Postfix wrap では **await 前に同期で `CommitSession`** して、
`UpdateSaveSlot` を経由しない `Save()` 経路（`OptionMenu` / `Album` / 各 Scene 多数）でも
作業データを取りこぼさない設計にしています。

### 非同期パッチの扱い
`Saves.Save` は `async UniTask` のため Harmony で直接パッチ不可（ステートマシンが生成される）。
代わりに Postfix で `ref UniTask __result` を受け取り、`.Preserve()` + 追加の `UniTask` で
ラップして永続化処理を後続させる方式を採用しています。

### フェイルセーフ
- `ExSaveData.Deserialize` は失敗時に空を返し、主セーブには一切触らない
- `ExSave` 由来の Texture で差し替えに失敗した場合は vanilla 320 にフォールバック
- `AlbumViewGate` は `Finalizer` で二重防御してフラグ漏洩を防止

## レビューのポイント

- [ChekiResolutionPatch.cs](BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs): IEnumerator 差し替えによる dual-capture と `ChekiHiResSidecar` のフレーム鮮度チェック
- [ExSaveLifecyclePatch.cs](BunnyGarden2FixMod/Patches/ExSaveLifecyclePatch.cs): async UniTask ラップ構造、await 前の同期 CommitSession
- [ExSaveSaveSlotTrackingPatch.cs](BunnyGarden2FixMod/Patches/ExSaveSaveSlotTrackingPatch.cs): `GameData.CopyFrom` 方向判別、アルバム閲覧識別
- [ChekiItemLoadHiResPatch.cs](BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs): magic byte 判別、サイズ検証による DoS 耐性

## 破壊的変更

- なし（既存の本体セーブには影響なし、MOD を外しても元通り動作）
- サイドカー `.exmod` はこの PR が初出のため後方互換考慮不要

---

## QA 確認項目

▼ どんな変更をして何を解決したか？
チェキ（撮影写真）の保存解像度が 320x320 固定だったのを任意解像度に変更可能にしました。
画像は MOD 専用のサイドカーファイル（主セーブに `.exmod` を付けた同階層のファイル）に
保存され、セーブスロット単位で分離管理されます。

▼ 既存影響あるか？
なし（既定 `HighResEnabled=false` で vanilla 挙動を完全維持）

▼ 期待値
1. 正常なケース:
   - \`HighResEnabled=true\` + \`Size=1024\` で撮影→セーブ→再起動→リストで高解像度チェキが復元
   - slot 0 で撮影→slot 1 に別名セーブ→slot 0 ロードで撮影前の状態に戻る（スロット分離）
   - \`ImageFormat=PNG\` / \`JPG\` 切替で \`.exmod\` サイズが変化
2. 異常なケース:
   - \`Size\` が範囲外（< 64 or > 2048）なら自動的にクランプ
   - \`.exmod\` が破損している場合は警告ログを出して空で開始、主セーブは無傷

▼ 確認内容
- \`HighResEnabled=false\`（既定）で挙動が一切変化しないこと
- \`HighResEnabled=true\` で撮影したチェキがチェキ一覧で高解像度表示されること
- BepInEx コンソールに各パッチの「適用」ログが出ていること:
  - \`[ChekiResolutionPatch]\`
  - \`[ChekiSaveHiResPatch]\`
  - \`[ChekiItemLoadHiResPatch]\`
  - \`[ExSaveOnLoadPatch]\` / \`[ExSaveOnSavePatch]\` / \`[ExSaveOnCreateNewDataPatch]\`
  - \`[GameDataCopyFromPatch]\` / \`[SaveDataUpdateSlotPatch]\` / \`[ExtraChekiSelectorViewPatch]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)