### PR TITLE
Add ChromaticAberrationPatch （色収差を無効化パッチ）

### DIFF
--- a/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
+++ b/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
@@ -88,6 +88,9 @@
     <Reference Include="Unity.RenderPipelines.Universal.Runtime">
       <HintPath>Assembly\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
     </Reference>
+    <Reference Include="Unity.RenderPipelines.Core.Runtime">
+      <HintPath>Assembly\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.InputSystem">
       <HintPath>Assembly\Unity.InputSystem.dll</HintPath>
     </Reference>

--- a/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
@@ -1,0 +1,16 @@
+using HarmonyLib;
+using UnityEngine.Rendering.Universal;
+
+namespace BunnyGarden2FixMod.Patches;
+
+[HarmonyPatch(typeof(ChromaticAberration), nameof(ChromaticAberration.IsActive))]
+public static class ChromaticAberrationPatch
+{
+    static bool Prefix(ChromaticAberration __instance, ref bool __result)
+    {
+        if (!Plugin.ConfigDisableChromaticAberration.Value)
+            return true;
+        __result = false;
+        return false;
+    }
+}

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -44,6 +44,7 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigExtraActive;
     public static ConfigEntry<int> ConfigFrameRate;
     public static ConfigEntry<AntiAliasingType> ConfigAntiAliasing;
+    public static ConfigEntry<bool> ConfigDisableChromaticAberration;
     public static ConfigEntry<float> ConfigSensitivity;
     public static ConfigEntry<float> ConfigSpeed;
     public static ConfigEntry<float> ConfigFastSpeed;
@@ -119,6 +120,12 @@ public class Plugin : BaseUnityPlugin
             "AntiAliasingType",
             AntiAliasingType.MSAA8x,
             "アンチエイリアシングの種類を指定します。右の方ほど画質が良くなりますが、動作が重くなります。Off / FXAA / TAA / MSAA2x / MSAA4x / MSAA8x");
+
+        ConfigDisableChromaticAberration = Config.Bind(
+            "ChromaticAberration",
+            "DisableChromaticAberration",
+            false,
+            "true にするとクロマティックアバレーション（色収差）エフェクトを無効化します。");
 
         ConfigSensitivity = Config.Bind(
             "Camera",


### PR DESCRIPTION
シンプルなprefixとconfig entryです。

<img width="545" height="443" alt="ChromaticAberration" src="https://github.com/user-attachments/assets/751e4f34-1f27-485a-9a33-755a044c39c3" />

ところで、resolution・framerate・anti aliasingとこのchromatic aberrationも全部「graphics」と呼ばれるカテゴリーに合致ですね？

下位互換性なし変更をしたくありませんでしたけど