### PR TITLE
feat(wardrobe): 水着コスチュームにストッキング／ニーハイを適用可能にする

### DIFF
--- a/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
+++ b/BunnyGarden2FixMod/BunnyGarden2FixMod.csproj
@@ -52,6 +52,8 @@
     <None Remove="Assembly\UnityEngine.UI.dll" />
     <None Remove="Assembly\MessagePack.dll" />
     <None Remove="Assembly\MessagePack.Annotations.dll" />
+    <None Remove="Assembly\Unity.Addressables.dll" />
+    <None Remove="Assembly\Unity.ResourceManager.dll" />
   </ItemGroup>
 
   <ItemGroup>
@@ -110,6 +112,14 @@
     </Reference>
     <Reference Include="MessagePack.Annotations">
       <HintPath>Assembly\MessagePack.Annotations.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Unity.Addressables">
+      <HintPath>Assembly\Unity.Addressables.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Unity.ResourceManager">
+      <HintPath>Assembly\Unity.ResourceManager.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/BlendShapeFalloffApplier.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/BlendShapeFalloffApplier.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using BunnyGarden2FixMod.Utils;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// 指定 blendShape の delta を、anchor 頂点群からの距離で線形フェードさせるユーティリティ。
+/// 各頂点で scale = clamp01(distToNearestAnchor / falloffRadius)（anchor 直近で 0、半径以上で 1）。
+///
+/// Unity API は既存 blendShape frame を直接編集できないので、
+/// 1) 全 shape を読み出し、2) ClearBlendShapes、3) 対象 shape は scale 倍した delta で、
+/// 非対象 shape は元 delta で AddBlendShapeFrame し直す形で実現する。
+///
+/// 想定用途: 水着 swim mesh_skin_lower の skin_stocking 系 blendShape を、
+/// 隣接 mesh（mesh_skin_upper など）の境界付近でだけフェードさせ、ウエスト等で段差を出さない。
+/// </summary>
+internal static class BlendShapeFalloffApplier
+{
+    /// <summary>
+    /// <paramref name="mesh"/> の <paramref name="shapesToScale"/> の各 shape 名について、
+    /// 全 frame の delta を per-vertex で <paramref name="falloffRadius"/> に基づきフェードする。
+    /// 対象外 shape はそのまま再 add される。
+    /// </summary>
+    /// <param name="mesh">対象 mesh。in-place で blendShape を書き換える。</param>
+    /// <param name="shapesToScale">フェード対象 shape 名リスト。mesh に存在しなければ無視。</param>
+    /// <param name="anchorVerts">距離計算に使う anchor 頂点列（mesh と同 mesh-local 座標系前提）。</param>
+    /// <param name="falloffRadius">フェード半径 (m)。&lt;= 0 で no-op。</param>
+    /// <param name="logTag">ログ用タグ。</param>
+    /// <returns>スケールを適用した shape の数。0 なら何もしていない。</returns>
+    internal static int Apply(Mesh mesh, IReadOnlyList<string> shapesToScale, Vector3[] anchorVerts, float falloffRadius, string logTag)
+    {
+        if (mesh == null || mesh.vertexCount == 0) return 0;
+        if (shapesToScale == null || shapesToScale.Count == 0) return 0;
+        if (anchorVerts == null || anchorVerts.Length == 0) return 0;
+        if (falloffRadius <= 0f) return 0;
+
+        int shapeCount = mesh.blendShapeCount;
+        if (shapeCount == 0) return 0;
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        var verts = mesh.vertices;
+        var anchorGrid = new SpatialGridIndex(anchorVerts);
+        var scale = new float[verts.Length];
+
+        long anchorStart = sw.ElapsedMilliseconds;
+        int faded = 0;
+        float minScale = 1f;
+        for (int i = 0; i < verts.Length; i++)
+        {
+            int j = anchorGrid.FindNearest(verts[i]);
+            if (j < 0) { scale[i] = 1f; continue; }
+            float d = (verts[i] - anchorVerts[j]).magnitude;
+            float sc = Mathf.Clamp01(d / falloffRadius);
+            scale[i] = sc;
+            if (sc < 0.999f) faded++;
+            if (sc < minScale) minScale = sc;
+        }
+        long anchorMs = sw.ElapsedMilliseconds - anchorStart;
+
+        // 既存 shape を全件読み出し（対象 shape は scale 倍する）
+        var scaleSet = new HashSet<string>(shapesToScale);
+        var saved = new List<(string name, List<(float weight, Vector3[] dv, Vector3[] dn, Vector3[] dt)> frames)>(shapeCount);
+        int scaledShapes = 0;
+        for (int s = 0; s < shapeCount; s++)
+        {
+            string name = mesh.GetBlendShapeName(s);
+            bool shouldScale = scaleSet.Contains(name);
+            int frameCount = mesh.GetBlendShapeFrameCount(s);
+            var frames = new List<(float, Vector3[], Vector3[], Vector3[])>(frameCount);
+            for (int f = 0; f < frameCount; f++)
+            {
+                float w = mesh.GetBlendShapeFrameWeight(s, f);
+                var dv = new Vector3[verts.Length];
+                var dn = new Vector3[verts.Length];
+                var dt = new Vector3[verts.Length];
+                mesh.GetBlendShapeFrameVertices(s, f, dv, dn, dt);
+                if (shouldScale)
+                {
+                    // dv は変位、dn/dt は方向。一様スケール (0..1) ならシェーディング上は近似で問題ないが、
+                    // 完全に正規直交を保つわけではないので、極端な強調が必要なら別途 RecalculateNormals を検討する。
+                    for (int i = 0; i < verts.Length; i++)
+                    {
+                        float sc = scale[i];
+                        dv[i] *= sc;
+                        dn[i] *= sc;
+                        dt[i] *= sc;
+                    }
+                }
+                frames.Add((w, dv, dn, dt));
+            }
+            if (shouldScale) scaledShapes++;
+            saved.Add((name, frames));
+        }
+
+        // Clear して同じ順序で再 add（index と name の対応を保つ）
+        mesh.ClearBlendShapes();
+        foreach (var (name, frames) in saved)
+        {
+            foreach (var (w, dv, dn, dt) in frames)
+            {
+                mesh.AddBlendShapeFrame(name, w, dv, dn, dt);
+            }
+        }
+
+        sw.Stop();
+        PatchLogger.LogInfo(
+            $"[{logTag}] blendShape falloff: mesh={mesh.name} verts={verts.Length} scaled={scaledShapes}/{shapeCount} radius={falloffRadius:F4}m anchors={anchorVerts.Length} faded={faded} minScale={minScale:F2} anchor={anchorMs}ms total={sw.ElapsedMilliseconds}ms");
+
+        return scaledShapes;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/BlendShapeFalloffApplier.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/BlendShapeFalloffApplier.cs
@@ -105,7 +105,7 @@ internal static class BlendShapeFalloffApplier
         }
 
         sw.Stop();
-        PatchLogger.LogInfo(
+        PatchLogger.LogDebug(
             $"[{logTag}] blendShape falloff: mesh={mesh.name} verts={verts.Length} scaled={scaledShapes}/{shapeCount} radius={falloffRadius:F4}m anchors={anchorVerts.Length} faded={faded} minScale={minScale:F2} anchor={anchorMs}ms total={sw.ElapsedMilliseconds}ms");
 
         return scaledShapes;

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
@@ -43,17 +43,48 @@ public class KneeSocksLoader : MonoBehaviour
         public float SkinKneehighBlend;
         public Mesh OriginalStockingsMesh;
         public Transform[] OriginalStockingsBones;
+        // blendShape 移植により sharedMesh を差し替えた場合のみセット（それ以外は null）
+        public Mesh LowerOriginalMesh;
     }
 
     private static readonly Dictionary<int, CharacterSnapshot> s_snapshots = new();
     private static CharacterHandle s_handle; // GC 防止: CharacterHandle が破棄されると SMR も破棄される
     private static SkinnedMeshRenderer s_kneeSocks;
+    // Luna Casual の mesh_skin_lower（skin_kneehigh blendShape のドナー）
+    private static Mesh s_donorSkinLower;
+    // 元 sharedMesh の InstanceID → blendShape 移植済みメッシュのキャッシュ。
+    // ドナーは固定（Luna Casual）で移植結果は元メッシュごとに決定的なため、charId なしのキーで安全。
+    // 異なるキャラが同一 sharedMesh を共有する場合は意図的に同じ結果を再利用する。
+    // ライフサイクル: シーン継続中は再利用（Restore 後も保持）、シーンアンロード時に Object.Destroy で破棄。
+    private static readonly Dictionary<int, Mesh> s_transplantedLowerCache = new();
 
     // インデックスは KneeSocksStockingType(type)。[0]=null（デフォルトは s_kneeSocks.material 直接使用）
     private static readonly Material[] s_stockingMaterials = new Material[3];
 
     /// <summary>マテリアルプリロード中かどうかを返す。DisableStockingPatch などのガードに使用する。</summary>
     public static bool IsPreloading { get; private set; }
+
+    /// <summary>
+    /// 水着×ニーソックス用: kneehigh SMR を借用してマテリアルを取得するためのアクセサ。
+    /// </summary>
+    internal static SkinnedMeshRenderer KneeSocksSmr => s_kneeSocks;
+
+    /// <summary>
+    /// 水着×ニーソックス用: Luna Casual の mesh_skin_lower ドナーを SwimWearStockingPatch に公開する。
+    /// プリロード未完了時は null を返す。
+    /// </summary>
+    internal static Mesh DonorSkinLower => s_donorSkinLower;
+
+    /// <summary>
+    /// 指定 override type（5-7）に対応する kneehigh マテリアルを返す。未ロード時は s_kneeSocks の既定マテリアルを返す。
+    /// </summary>
+    internal static Material GetMaterialForOverride(int overrideType)
+    {
+        int idx = StockingOverrideStore.KneeSocksStockingType(overrideType);
+        if (idx > 0 && idx < s_stockingMaterials.Length && s_stockingMaterials[idx] != null)
+            return s_stockingMaterials[idx];
+        return s_kneeSocks != null ? s_kneeSocks.sharedMaterial : null;
+    }
 
     public static void Initialize(GameObject parent)
     {
@@ -83,6 +114,19 @@ public class KneeSocksLoader : MonoBehaviour
             PatchLogger.LogWarning($"[{nameof(KneeSocksLoader)}] mesh_kneehigh が見つかりませんでした。ニーソックスは使用できません。");
         else
             PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] mesh_kneehigh をプリロードしました。");
+
+        // Luna Casual の mesh_skin_lower から skin_kneehigh blendShape をドナーとしてキャッシュ
+        var donorLowerSmr = parent.GetComponentsInChildren<SkinnedMeshRenderer>(true)
+            .FirstOrDefault(m => m.name == "mesh_skin_lower");
+        if (donorLowerSmr != null && donorLowerSmr.sharedMesh != null)
+        {
+            s_donorSkinLower = donorLowerSmr.sharedMesh;
+            PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] mesh_skin_lower ドナーをキャッシュしました (verts={s_donorSkinLower.vertexCount} shapes={s_donorSkinLower.blendShapeCount})。");
+        }
+        else
+        {
+            PatchLogger.LogWarning($"[{nameof(KneeSocksLoader)}] mesh_skin_lower が見つかりませんでした。skin_kneehigh 移植はフォールバック動作になります。");
+        }
 
         // ダミーキャラの mesh_stockings に ApplyStocking を呼んでマテリアルをキャッシュする
         var stockingsMesh = parent.GetComponentsInChildren<SkinnedMeshRenderer>(true)
@@ -115,7 +159,16 @@ public class KneeSocksLoader : MonoBehaviour
     private static void OnSceneUnloaded(Scene scene)
     {
         s_snapshots.Clear();
-        PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] シーンアンロードに伴いスナップショットをクリアしました。");
+
+        // 移植済みメッシュを破棄してリークを防ぐ
+        int destroyed = 0;
+        foreach (var m in s_transplantedLowerCache.Values)
+        {
+            if (m != null) { Object.Destroy(m); destroyed++; }
+        }
+        s_transplantedLowerCache.Clear();
+
+        PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] シーンアンロード: スナップショットクリア、transplanted mesh {destroyed} 件破棄。");
     }
 
     /// <summary>
@@ -154,6 +207,7 @@ public class KneeSocksLoader : MonoBehaviour
                 SkinKneehighBlend = lower != null ? GetBlendShapeWeight(lower, "blendShape_skin_lower.skin_kneehigh") : 0f,
                 OriginalStockingsMesh = stockings.sharedMesh,
                 OriginalStockingsBones = stockings.bones,
+                LowerOriginalMesh = null,
             };
         }
 
@@ -186,11 +240,58 @@ public class KneeSocksLoader : MonoBehaviour
             : s_kneeSocks.material;
         stockings.bones = mappedBones;
 
-        // blendshape 修正: stocking スロットを使うので skin_stocking=100, skin_kneehigh=0
+        // z-fighting 対策: skin_kneehigh=100 がニーハイ専用シェイプのため理想的。
+        // skin_kneehigh は Luna Casual の mesh_skin_lower にしか存在しないため、他キャラ／コスチュームには移植が必要。
         if (lower != null)
         {
-            SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", 100f);
-            SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", 0f);
+            int kneehighIdx = lower.sharedMesh.GetBlendShapeIndex("blendShape_skin_lower.skin_kneehigh");
+            if (kneehighIdx >= 0)
+            {
+                // 既存に skin_kneehigh がある（Luna Casual 等）: そのまま weight を設定
+                SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", 0f);
+                SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", 100f);
+            }
+            else if (s_donorSkinLower != null)
+            {
+                // skin_kneehigh がない場合: Luna Casual ドナーから nearest-neighbor 移植
+                int origId = lower.sharedMesh.GetInstanceID();
+                if (!s_transplantedLowerCache.TryGetValue(origId, out var transplanted) || transplanted == null)
+                {
+                    transplanted = MeshBlendShapeTransplanter.Transplant(
+                        lower.sharedMesh,
+                        s_donorSkinLower,
+                        new[] { "blendShape_skin_lower.skin_kneehigh" },
+                        nameof(KneeSocksLoader));
+                    if (transplanted != null)
+                        s_transplantedLowerCache[origId] = transplanted;
+                }
+
+                if (transplanted != null)
+                {
+                    // snapshot に元 sharedMesh を記録してから差し替え
+                    var snap = s_snapshots[instanceId];
+                    snap.LowerOriginalMesh = lower.sharedMesh;
+                    s_snapshots[instanceId] = snap;
+
+                    lower.sharedMesh = transplanted;
+                    SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", 0f);
+                    SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", 100f);
+                }
+                else
+                {
+                    // 移植結果が null（shape なし等）: フォールバック
+                    PatchLogger.LogWarning($"[{nameof(KneeSocksLoader)}] 移植結果が null のためフォールバック (skin_stocking=100)");
+                    SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", 100f);
+                    SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", 0f);
+                }
+            }
+            else
+            {
+                // ドナー未取得: フォールバック（skin_stocking=100 で z-fighting を最低限抑制）
+                PatchLogger.LogWarning($"[{nameof(KneeSocksLoader)}] ドナー mesh_skin_lower 未取得のためフォールバック (skin_stocking=100)");
+                SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", 100f);
+                SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", 0f);
+            }
         }
 
         PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] ニーソックスを適用しました: {character.name}");
@@ -203,6 +304,8 @@ public class KneeSocksLoader : MonoBehaviour
     {
         if (IsPreloading) return; // プリロード中の dummy handle への誤適用を防ぐ
         if (handle?.Chara == null) return;
+        // 水着は SwimWearStockingPatch が専用ロジックで処理するためスキップ
+        if (handle.m_lastLoadArg != null && handle.m_lastLoadArg.Costume == CostumeType.SwimWear) return;
         var id = handle.GetCharID();
         if (!StockingOverrideStore.TryGet(id, out var stk) || !StockingOverrideStore.IsKneeSocksType(stk)) return;
         Apply(handle.Chara, stk);
@@ -210,6 +313,7 @@ public class KneeSocksLoader : MonoBehaviour
 
     private static void SetBlendShape(SkinnedMeshRenderer renderer, string name, float weight)
     {
+        if (renderer == null || renderer.sharedMesh == null) return;
         int idx = renderer.sharedMesh.GetBlendShapeIndex(name);
         if (idx >= 0) renderer.SetBlendShapeWeight(idx, weight);
     }
@@ -243,6 +347,10 @@ public class KneeSocksLoader : MonoBehaviour
         if (socks != null) socks.gameObject.SetActive(snap.SocksActive);
         if (lower != null)
         {
+            // 移植により sharedMesh を差し替えていた場合は先に元に戻す（blendShape index が変わるため）
+            if (snap.LowerOriginalMesh != null)
+                lower.sharedMesh = snap.LowerOriginalMesh;
+
             SetBlendShape(lower, "blendShape_skin_lower.skin_stocking", snap.SkinStockingBlend);
             SetBlendShape(lower, "blendShape_skin_lower.skin_kneehigh", snap.SkinKneehighBlend);
         }

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
@@ -160,15 +160,15 @@ public class KneeSocksLoader : MonoBehaviour
     {
         s_snapshots.Clear();
 
-        // 移植済みメッシュを破棄してリークを防ぐ
-        int destroyed = 0;
-        foreach (var m in s_transplantedLowerCache.Values)
-        {
-            if (m != null) { Object.Destroy(m); destroyed++; }
-        }
+        // 移植済みメッシュは Destroy しない:
+        //   キャラ GameObject が DontDestroyOnLoad 等でシーンを跨いで生存するケースがあり、
+        //   その lower SMR が transplanted mesh を参照したまま次シーンに入ると、ここで Destroy
+        //   していると fake-null mesh を抱えて肌が消える。
+        //   キャッシュ辞書だけクリアし、Mesh は SMR が手放した時点で Unity GC に回収させる。
+        int transplantedCount = s_transplantedLowerCache.Count;
         s_transplantedLowerCache.Clear();
 
-        PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] シーンアンロード: スナップショットクリア、transplanted mesh {destroyed} 件破棄。");
+        PatchLogger.LogInfo($"[{nameof(KneeSocksLoader)}] シーンアンロード: snapshot クリア、transplanted cache クリア (mesh {transplantedCount} 件)。");
     }
 
     /// <summary>
@@ -242,7 +242,8 @@ public class KneeSocksLoader : MonoBehaviour
 
         // z-fighting 対策: skin_kneehigh=100 がニーハイ専用シェイプのため理想的。
         // skin_kneehigh は Luna Casual の mesh_skin_lower にしか存在しないため、他キャラ／コスチュームには移植が必要。
-        if (lower != null)
+        // タイトル戻りなどで sharedMesh が null 化することがあるため lower.sharedMesh も確認する。
+        if (lower != null && lower.sharedMesh != null)
         {
             int kneehighIdx = lower.sharedMesh.GetBlendShapeIndex("blendShape_skin_lower.skin_kneehigh");
             if (kneehighIdx >= 0)
@@ -320,6 +321,7 @@ public class KneeSocksLoader : MonoBehaviour
 
     private static float GetBlendShapeWeight(SkinnedMeshRenderer renderer, string name)
     {
+        if (renderer == null || renderer.sharedMesh == null) return 0f;
         int idx = renderer.sharedMesh.GetBlendShapeIndex(name);
         return idx >= 0 ? renderer.GetBlendShapeWeight(idx) : 0f;
     }

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
@@ -67,21 +67,11 @@ internal static class MeshBlendShapeTransplanter
 
             // このドナー用 nearest-neighbor 索引: targetVert[i] → donorVert の最近傍 index
             long nearestStart = sw.ElapsedMilliseconds;
+            var grid = new SpatialGridIndex(donorVerts);
             var nearestMap = new int[targetVerts.Length];
             for (int i = 0; i < targetVerts.Length; i++)
             {
-                float minD = float.MaxValue;
-                int minJ = 0;
-                var tv = targetVerts[i];
-                for (int j = 0; j < donorVerts.Length; j++)
-                {
-                    var dx = donorVerts[j].x - tv.x;
-                    var dy = donorVerts[j].y - tv.y;
-                    var dz = donorVerts[j].z - tv.z;
-                    float sq = dx * dx + dy * dy + dz * dz;
-                    if (sq < minD) { minD = sq; minJ = j; }
-                }
-                nearestMap[i] = minJ;
+                nearestMap[i] = grid.FindNearest(targetVerts[i]);
             }
             nearestMsTotal += sw.ElapsedMilliseconds - nearestStart;
 

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
@@ -108,7 +108,7 @@ internal static class MeshBlendShapeTransplanter
         }
 
         sw.Stop();
-        PatchLogger.LogInfo(
+        PatchLogger.LogDebug(
             $"[{logTag}] blendShape 移植完了: target={targetMesh.name} verts={targetVerts.Length} donors={donors.Count} shapes={shapesAdded} nearest={nearestMsTotal}ms total={sw.ElapsedMilliseconds}ms");
 
         // 移植できた shape が 0 件の場合は不要なメッシュを返さない

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshBlendShapeTransplanter.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using BunnyGarden2FixMod.Utils;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// targetMesh の頂点構造を保ったまま、donorMesh の指定 blendShape delta を
+/// nearest-neighbor で転写した新 Mesh を生成する共通ユーティリティ。
+/// キャッシュは持たない（呼出し側が個別保持する）。
+/// </summary>
+internal static class MeshBlendShapeTransplanter
+{
+    /// <summary>
+    /// <paramref name="targetMesh"/> を複製し、<paramref name="donorMesh"/> の
+    /// <paramref name="shapeNames"/> に列挙された blendShape を nearest-neighbor で移植した Mesh を返す。
+    /// 移植対象 shape が donorMesh に存在しない場合はスキップされる。
+    /// </summary>
+    /// <param name="targetMesh">移植先メッシュ（変更されない。複製して使用）。</param>
+    /// <param name="donorMesh">移植元 blendShape を持つメッシュ。</param>
+    /// <param name="shapeNames">移植する blendShape 名のリスト。</param>
+    /// <param name="logTag">ログ出力に使うタグ文字列（例: "KneeSocksLoader"）。</param>
+    /// <returns>移植済み新メッシュ。移植できる shape がゼロの場合は null を返す。</returns>
+    internal static Mesh Transplant(Mesh targetMesh, Mesh donorMesh, IReadOnlyList<string> shapeNames, string logTag)
+    {
+        // 単一ドナー版は複数ドナー版に委譲
+        return Transplant(
+            targetMesh,
+            new (Mesh donor, IReadOnlyList<string> shapeNames)[] { (donorMesh, shapeNames) },
+            logTag);
+    }
+
+    /// <summary>
+    /// <paramref name="targetMesh"/> を複製し、複数ドナーそれぞれの blendShape を
+    /// nearest-neighbor で移植した Mesh を返す。
+    /// 各ドナーについて独立した nearest-neighbor マップを計算して frame を追加する。
+    /// 移植対象 shape が donorMesh に存在しない場合はスキップされる。
+    /// </summary>
+    /// <param name="targetMesh">移植先メッシュ（変更されない。複製して使用）。</param>
+    /// <param name="donors">ドナーと移植する blendShape 名リストのペア列。</param>
+    /// <param name="logTag">ログ出力に使うタグ文字列（例: "SwimWearStockingPatch"）。</param>
+    /// <returns>移植済み新メッシュ。移植できる shape がゼロの場合は null を返す。</returns>
+    internal static Mesh Transplant(
+        Mesh targetMesh,
+        IReadOnlyList<(Mesh donor, IReadOnlyList<string> shapeNames)> donors,
+        string logTag)
+    {
+        if (targetMesh == null || donors == null || donors.Count == 0) return null;
+
+        var targetVerts = targetMesh.vertices;
+        if (targetVerts.Length == 0) return null;
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        var newMesh = Object.Instantiate(targetMesh);
+        newMesh.name = targetMesh.name + "_transplanted";
+
+        int shapesAdded = 0;
+        long nearestMsTotal = 0;
+
+        foreach (var (donorMesh, shapeNames) in donors)
+        {
+            if (donorMesh == null || donorMesh.blendShapeCount == 0) continue;
+
+            var donorVerts = donorMesh.vertices;
+            if (donorVerts.Length == 0) continue;
+
+            // このドナー用 nearest-neighbor 索引: targetVert[i] → donorVert の最近傍 index
+            long nearestStart = sw.ElapsedMilliseconds;
+            var nearestMap = new int[targetVerts.Length];
+            for (int i = 0; i < targetVerts.Length; i++)
+            {
+                float minD = float.MaxValue;
+                int minJ = 0;
+                var tv = targetVerts[i];
+                for (int j = 0; j < donorVerts.Length; j++)
+                {
+                    var dx = donorVerts[j].x - tv.x;
+                    var dy = donorVerts[j].y - tv.y;
+                    var dz = donorVerts[j].z - tv.z;
+                    float sq = dx * dx + dy * dy + dz * dz;
+                    if (sq < minD) { minD = sq; minJ = j; }
+                }
+                nearestMap[i] = minJ;
+            }
+            nearestMsTotal += sw.ElapsedMilliseconds - nearestStart;
+
+            foreach (var shapeName in shapeNames)
+            {
+                int idx = donorMesh.GetBlendShapeIndex(shapeName);
+                if (idx < 0) continue;
+                // すでに同名 shape がある場合はスキップ（二重追加防止）
+                if (newMesh.GetBlendShapeIndex(shapeName) >= 0) continue;
+
+                int frameCount = donorMesh.GetBlendShapeFrameCount(idx);
+                for (int f = 0; f < frameCount; f++)
+                {
+                    var donorDv = new Vector3[donorMesh.vertexCount];
+                    var donorDn = new Vector3[donorMesh.vertexCount];
+                    var donorDt = new Vector3[donorMesh.vertexCount];
+                    donorMesh.GetBlendShapeFrameVertices(idx, f, donorDv, donorDn, donorDt);
+
+                    var newDv = new Vector3[targetMesh.vertexCount];
+                    var newDn = new Vector3[targetMesh.vertexCount];
+                    var newDt = new Vector3[targetMesh.vertexCount];
+                    for (int k = 0; k < targetMesh.vertexCount; k++)
+                    {
+                        int src = nearestMap[k];
+                        newDv[k] = donorDv[src];
+                        newDn[k] = donorDn[src];
+                        // tangent delta は 0 のまま（SwimWear 移植と同仕様）
+                    }
+                    float weight = donorMesh.GetBlendShapeFrameWeight(idx, f);
+                    newMesh.AddBlendShapeFrame(shapeName, weight, newDv, newDn, newDt);
+                }
+                shapesAdded++;
+            }
+        }
+
+        sw.Stop();
+        PatchLogger.LogInfo(
+            $"[{logTag}] blendShape 移植完了: target={targetMesh.name} verts={targetVerts.Length} donors={donors.Count} shapes={shapesAdded} nearest={nearestMsTotal}ms total={sw.ElapsedMilliseconds}ms");
+
+        // 移植できた shape が 0 件の場合は不要なメッシュを返さない
+        if (shapesAdded == 0)
+        {
+            Object.Destroy(newMesh);
+            return null;
+        }
+
+        return newMesh;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshPenetrationResolver.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshPenetrationResolver.cs
@@ -1,0 +1,302 @@
+using BunnyGarden2FixMod.Utils;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// donor mesh (mesh_stockings) と reference mesh (swim mesh_skin_lower) の食い込みを
+/// 2 パスの近傍探索で検出し、両側に押し出して解消するユーティリティ。
+///
+/// pass 1 (stocking push): donor 頂点ごとに skin 表面までの符号付き距離 signedD を計算。
+///   signedD &lt; minOffset の場合、donor を法線方向に (minOffset - signedD) だけ外側へ push。
+///   signedD &gt;= minOffset の場合は不変。
+///
+/// pass 2 (skin push): skin 頂点ごとに、pass1 で押し出された後の donor 表面までの
+///   符号付き距離 signedD を計算。
+///   目標は「stocking 表面 (vAvg) からさらに skinPushAmount だけ内側に skin を置く」こと。
+///   必要押し込み量 = skinPushAmount - signedD（signedD は内側で正、突き抜けで負）。
+///     突き抜け (signedD &lt; 0) → skinPushAmount + |signedD| のフル押し込み
+///     不足 (0 &lt;= signedD &lt; skinPushAmount) → 不足分のみ
+///     既に十分内側 (signedD &gt;= skinPushAmount) → 何もしない（外へ引き戻さない）
+///
+/// 旧 MeshSurfaceOffsetAdjuster + MeshSurfaceShrinker を統合した上位互換。
+/// 検出を 1 回しか走らせないため一様 shrink より高速かつ局所的に作用する。
+/// </summary>
+internal static class MeshPenetrationResolver
+{
+    /// <summary>
+    /// donor と reference を 1 パスで処理し、食い込みを解消した両 mesh を返す。
+    /// </summary>
+    /// <param name="donorMesh">補正対象 donor (mesh_stockings 元)。変更されない。</param>
+    /// <param name="referenceMesh">基準 mesh (swim mesh_skin_lower の transplanted 後)。変更されない。</param>
+    /// <param name="referenceShape">基準 mesh の weight=100 適用 blendShape 名 (例 "blendShape_skin_lower.skin_stocking")。</param>
+    /// <param name="minOffset">stocking 食い込み判定閾値 兼 stocking push 後の最小距離 (m)。&lt;= 0 で stocking push 無効。</param>
+    /// <param name="skinPushAmount">stocking 押し出し後表面から内側へ skin を置く目標距離 (m)。
+    /// 突き抜けがあれば「表面まで揃える + skinPushAmount」のフル押し込みになる。&lt;= 0 で skin push 無効。</param>
+    /// <param name="skinAnchorVerts">skin push の falloff anchor (隣接 skin mesh 頂点)。null/空なら falloff 無し。</param>
+    /// <param name="skinFalloffRadius">skin push の境界フェード半径 (m)。&lt;= 0 で falloff 無し。</param>
+    /// <param name="logTag">ログ出力タグ。</param>
+    /// <returns>(adjusted donor, adjusted skin)。それぞれ null なら no-op（差し替え不要）。</returns>
+    internal static (Mesh donor, Mesh skin) Resolve(
+        Mesh donorMesh, Mesh referenceMesh, string referenceShape,
+        float minOffset, float skinPushAmount,
+        Vector3[] skinAnchorVerts, float skinFalloffRadius,
+        string logTag)
+    {
+        if (donorMesh == null || referenceMesh == null) return (null, null);
+        if (minOffset <= 0f && skinPushAmount <= 0f) return (null, null);
+
+        var donorVerts = donorMesh.vertices;
+        if (donorVerts.Length == 0) return (null, null);
+        var donorNormals = donorMesh.normals;
+        bool hasDonorNormals = donorNormals != null && donorNormals.Length == donorVerts.Length;
+
+        var refVerts = referenceMesh.vertices;
+        var refNormals = referenceMesh.normals;
+        if (refVerts.Length == 0 || refNormals.Length != refVerts.Length) return (null, null);
+
+        // referenceShape weight=100 を再現する
+        if (!string.IsNullOrEmpty(referenceShape))
+        {
+            int idx = referenceMesh.GetBlendShapeIndex(referenceShape);
+            if (idx < 0 || referenceMesh.GetBlendShapeFrameCount(idx) == 0)
+            {
+                PatchLogger.LogWarning(
+                    $"[{logTag}] reference blendShape '{referenceShape}' が見つからない (referenceMesh={referenceMesh.name})、補正スキップ");
+                return (null, null);
+            }
+            int lastFrame = referenceMesh.GetBlendShapeFrameCount(idx) - 1;
+            var dv = new Vector3[refVerts.Length];
+            var dn = new Vector3[refVerts.Length];
+            var dt = new Vector3[refVerts.Length];
+            referenceMesh.GetBlendShapeFrameVertices(idx, lastFrame, dv, dn, dt);
+            for (int i = 0; i < refVerts.Length; i++)
+            {
+                refVerts[i] += dv[i];
+                refNormals[i] = (refNormals[i] + dn[i]).normalized;
+            }
+        }
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        long gridStart = sw.ElapsedMilliseconds;
+        var refGrid = new SpatialGridIndex(refVerts);
+        var donorGrid = skinPushAmount > 0f ? new SpatialGridIndex(donorVerts) : null;
+        long gridMs = sw.ElapsedMilliseconds - gridStart;
+
+        // skin push の anchor falloff scale を skin 頂点ごとに事前計算
+        // skinScale[i] = clamp(distToAnchor / falloffRadius, 0, 1)
+        var skinScale = new float[refVerts.Length];
+        long anchorMs = 0;
+        if (skinPushAmount > 0f && skinAnchorVerts != null && skinAnchorVerts.Length > 0 && skinFalloffRadius > 0f)
+        {
+            long aStart = sw.ElapsedMilliseconds;
+            var anchorGrid = new SpatialGridIndex(skinAnchorVerts);
+            for (int i = 0; i < refVerts.Length; i++)
+            {
+                int j = anchorGrid.FindNearest(refVerts[i]);
+                if (j < 0) { skinScale[i] = 1f; continue; }
+                float d = (refVerts[i] - skinAnchorVerts[j]).magnitude;
+                skinScale[i] = Mathf.Clamp01(d / skinFalloffRadius);
+            }
+            anchorMs = sw.ElapsedMilliseconds - aStart;
+        }
+        else
+        {
+            for (int i = 0; i < refVerts.Length; i++) skinScale[i] = 1f;
+        }
+
+        // invertGuard: 法線逆向きや別パーツへの誤近傍ヒットを弾く
+        const float invertGuardMul = 10f;
+        float invertGuardBase = Mathf.Max(minOffset, skinPushAmount);
+        float invertGuard = -invertGuardBase * invertGuardMul;
+
+        // 近傍重み付け補間: K-nearest を逆距離² 重みで補間して surface 推定点を出す。
+        // K=3 にすると三角形パッチ相当の重み付けになり、頂点位置がズレていても
+        // 局所表面に近い position/normal が得られる。
+        const int neighborK = 3;
+        const float weightEps = 1e-8f;
+
+        var donorDisp = new Vector3[donorVerts.Length];
+        var skinDisp = new Vector3[refVerts.Length];
+        var neighbors = new System.Collections.Generic.List<int>(16);
+
+        // ------- pass 1: stocking push (donor 頂点 → 近傍 skin の重み付け平均) -------
+        int pushed = 0, skippedInverted = 0, stockingFallback = 0;
+        float maxStockingPush = 0f;
+        long stockingMs = 0;
+        if (minOffset > 0f)
+        {
+            long pStart = sw.ElapsedMilliseconds;
+            for (int i = 0; i < donorVerts.Length; i++)
+            {
+                var v = donorVerts[i];
+                Vector3 sAvg, snAvg;
+
+                neighbors.Clear();
+                refGrid.FindKNearest(v, neighborK, neighbors);
+                if (neighbors.Count == 0) continue;
+                if (neighbors.Count < neighborK) stockingFallback++;
+
+                {
+                    Vector3 sSum = Vector3.zero, snSum = Vector3.zero;
+                    float wSum = 0f;
+                    for (int k = 0; k < neighbors.Count; k++)
+                    {
+                        int nj = neighbors[k];
+                        var sp = refVerts[nj];
+                        float dsq = (sp - v).sqrMagnitude;
+                        float w = 1f / (dsq + weightEps);
+                        sSum += sp * w;
+                        snSum += refNormals[nj] * w;
+                        wSum += w;
+                    }
+                    sAvg = sSum / wSum;
+                    snAvg = snSum.sqrMagnitude > 1e-12f ? snSum.normalized : refNormals[neighbors[0]];
+                }
+
+                // signedD = dot(v - sAvg, snAvg): skin 側 reference frame での stocking の位置。
+                // snAvg は skin の外向き法線。
+                //   signedD > 0 → stocking が skin 表面の +snAvg 側 = 外側にいる（通常）
+                //   signedD = 0 → stocking がちょうど skin 表面上
+                //   signedD < 0 → stocking が skin に食い込んでいる
+                float signedD = Vector3.Dot(v - sAvg, snAvg);
+                if (signedD < invertGuard) { skippedInverted++; continue; }
+
+                // まず stocking を skin 表面 (sAvg) まで揃え、そこから更に minOffset
+                // だけ外側 (+snAvg 方向) に押し出す。
+                // 目標位置 = sAvg + snAvg * minOffset
+                // 法線方向の必要変位 = minOffset - signedD
+                //   signedD < 0 (食い込み): minOffset + |signedD| をフル push
+                //   0 <= signedD < minOffset: 不足分のみ push
+                //   signedD >= minOffset: 既に十分外側 → 何もしない（内側へ引き戻さない）
+                float pushDist = minOffset - signedD;
+                if (pushDist > 0f)
+                {
+                    donorDisp[i] = snAvg * pushDist;
+                    if (pushDist > maxStockingPush) maxStockingPush = pushDist;
+                    pushed++;
+                }
+            }
+            stockingMs = sw.ElapsedMilliseconds - pStart;
+        }
+
+        // ------- pass 2: skin push (skin 頂点 → 近傍 donor の重み付け平均) -------
+        // skin 頂点ごとに直接判定するため、donor 数より skin 数が多くても全頂点をカバーできる。
+        // pass1 で押し出された donor 位置 (donorVerts[nj] + donorDisp[nj]) を参照することで、
+        // stocking push で既に十分なクリアランスが取れた箇所では skin push が発火しない。
+        //
+        // 押し込み方向は donor 側の重み付け法線 vnAvg（pass1 の snAvg と対称）を採用する。
+        // skin 頂点自体の法線 sn を使うと、近傍 donor 群と方向が乖離して押し込みが横方向に
+        // 流れることがあるため。
+        int skinHits = 0, skinSkippedInverted = 0, skinFallback = 0;
+        long skinDetectMs = 0;
+        if (skinPushAmount > 0f && donorGrid != null && hasDonorNormals)
+        {
+            long pStart = sw.ElapsedMilliseconds;
+            for (int i = 0; i < refVerts.Length; i++)
+            {
+                var s = refVerts[i];
+                Vector3 vAvg, vnAvg;
+
+                neighbors.Clear();
+                donorGrid.FindKNearest(s, neighborK, neighbors);
+                if (neighbors.Count == 0) continue;
+                if (neighbors.Count < neighborK) skinFallback++;
+
+                {
+                    Vector3 vSum = Vector3.zero, vnSum = Vector3.zero;
+                    float wSum = 0f;
+                    for (int k = 0; k < neighbors.Count; k++)
+                    {
+                        int nj = neighbors[k];
+                        var vp = donorVerts[nj] + donorDisp[nj];
+                        float dsq = (vp - s).sqrMagnitude;
+                        float w = 1f / (dsq + weightEps);
+                        vSum += vp * w;
+                        vnSum += donorNormals[nj] * w;
+                        wSum += w;
+                    }
+                    vAvg = vSum / wSum;
+                    vnAvg = vnSum.sqrMagnitude > 1e-12f ? vnSum.normalized : donorNormals[neighbors[0]];
+                }
+
+                // signedD = dot(vAvg - s, vnAvg): donor 側 reference frame での skin の位置。
+                // vnAvg は stocking の外向き法線。
+                //   signedD > 0 → skin は stocking 表面 (vAvg) の -vnAvg 側 = 内側にいる（通常）
+                //   signedD = 0 → skin はちょうど stocking 表面上
+                //   signedD < 0 → skin が stocking を突き抜けて外側に出ている（食い込み）
+                float signedD = Vector3.Dot(vAvg - s, vnAvg);
+                if (signedD < invertGuard) { skinSkippedInverted++; continue; }
+
+                float scaledPush = skinPushAmount * skinScale[i];
+                if (scaledPush <= 0f) continue;
+
+                // まず skin を stocking 押し出し後表面 (vAvg) まで揃え、そこから更に
+                // scaledPush だけ内側 (-vnAvg 方向) に押し込む。
+                // 目標位置 = vAvg + (-vnAvg) * scaledPush
+                // 法線方向の必要変位 = scaledPush - signedD
+                //   signedD < 0 (突き抜け): scaledPush + |signedD| をフル push
+                //   0 <= signedD < scaledPush: 不足分のみ push
+                //   signedD >= scaledPush: 既に十分内側 → 何もしない（外へ引き戻さない）
+                float pushDist = scaledPush - signedD;
+                if (pushDist > 0f)
+                {
+                    skinDisp[i] = -vnAvg * pushDist;
+                    skinHits++;
+                }
+            }
+            skinDetectMs = sw.ElapsedMilliseconds - pStart;
+        }
+
+        // donor 補正 mesh
+        Mesh adjDonor = null;
+        if (pushed > 0 && minOffset > 0f)
+        {
+            adjDonor = Object.Instantiate(donorMesh);
+            adjDonor.name = donorMesh.name + "_offset";
+            for (int i = 0; i < donorVerts.Length; i++)
+            {
+                donorVerts[i] += donorDisp[i];
+            }
+            adjDonor.vertices = donorVerts;
+            adjDonor.RecalculateNormals();
+            adjDonor.RecalculateBounds();
+        }
+
+        // skin 補正 mesh
+        // base 頂点を直接書き換える（runtime に skin_stocking blendShape weight=100 が
+        // 加算されるため、base からの -sn*y で visual 位置が y だけ内側へ寄る）
+        Mesh adjSkin = null;
+        float maxSkinPush = 0f;
+        if (skinHits > 0)
+        {
+            var skinBaseVerts = referenceMesh.vertices;
+            for (int i = 0; i < skinBaseVerts.Length; i++)
+            {
+                var d = skinDisp[i];
+                if (d.sqrMagnitude > 0f)
+                {
+                    skinBaseVerts[i] += d;
+                    float m = d.magnitude;
+                    if (m > maxSkinPush) maxSkinPush = m;
+                }
+            }
+            adjSkin = Object.Instantiate(referenceMesh);
+            adjSkin.name = referenceMesh.name + "_resolved";
+            adjSkin.vertices = skinBaseVerts;
+            adjSkin.RecalculateBounds();
+            // base normals は意図的に再計算しない（局所的な内側 offset でシェーディングは
+            // ほぼ不変。再計算するとアンビエント差が出やすいので避ける）。
+        }
+
+        sw.Stop();
+        PatchLogger.LogInfo(
+            $"[{logTag}] penetration resolve: donor={donorMesh.name}({donorVerts.Length}v) ref={referenceMesh.name}({refVerts.Length}v) " +
+            $"stockingPushed={pushed} skippedInv={skippedInverted} fallback={stockingFallback} stockingMax={maxStockingPush:F4}m " +
+            $"skinPushed={skinHits} skinSkippedInv={skinSkippedInverted} skinFallback={skinFallback} skinMax={maxSkinPush:F4}m " +
+            $"grid={gridMs}ms anchor={anchorMs}ms stocking={stockingMs}ms skinDetect={skinDetectMs}ms total={sw.ElapsedMilliseconds}ms");
+
+        return (adjDonor, adjSkin);
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshPenetrationResolver.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshPenetrationResolver.cs
@@ -291,7 +291,7 @@ internal static class MeshPenetrationResolver
         }
 
         sw.Stop();
-        PatchLogger.LogInfo(
+        PatchLogger.LogDebug(
             $"[{logTag}] penetration resolve: donor={donorMesh.name}({donorVerts.Length}v) ref={referenceMesh.name}({refVerts.Length}v) " +
             $"stockingPushed={pushed} skippedInv={skippedInverted} fallback={stockingFallback} stockingMax={maxStockingPush:F4}m " +
             $"skinPushed={skinHits} skinSkippedInv={skinSkippedInverted} skinFallback={skinFallback} skinMax={maxSkinPush:F4}m " +

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/MeshSurfaceOffsetAdjuster.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/MeshSurfaceOffsetAdjuster.cs
@@ -1,0 +1,126 @@
+using BunnyGarden2FixMod.Utils;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// donorMesh の頂点を referenceMesh（の指定 blendShape weight=100 状態）の表面より
+/// minOffset メートル外側に押し出した新 Mesh を返すユーティリティ。
+/// referenceShape を指定することで、blendShape による変形後の表面を基準にできる。
+/// 元 mesh の topology / UV / bone weight / 既存 blendShape はすべてそのまま保持する。
+/// </summary>
+internal static class MeshSurfaceOffsetAdjuster
+{
+    /// <summary>
+    /// <paramref name="donorMesh"/> を複製し、<paramref name="referenceMesh"/> の
+    /// <paramref name="referenceShape"/> を weight=100 で適用した状態の表面より
+    /// <paramref name="minOffset"/> メートル外側に頂点を押し出した新 Mesh を返す。
+    /// </summary>
+    /// <param name="donorMesh">補正対象 (mesh_stockings 元)。変更されない。</param>
+    /// <param name="referenceMesh">基準メッシュ (swim mesh_skin_lower の transplanted 後)。</param>
+    /// <param name="referenceShape">基準とする blendShape 名。null/空なら base verts を使う。未存在時は null 返却。</param>
+    /// <param name="minOffset">押し出し最小距離 (m)。<= 0 なら no-op で null を返す。</param>
+    /// <param name="logTag">ログ出力タグ。</param>
+    /// <returns>補正済み新 Mesh。no-op or 入力不正時は null。</returns>
+    internal static Mesh Adjust(Mesh donorMesh, Mesh referenceMesh, string referenceShape, float minOffset, string logTag)
+    {
+        if (donorMesh == null || referenceMesh == null) return null;
+        if (minOffset <= 0f) return null;
+
+        var donorVerts = donorMesh.vertices;
+        if (donorVerts.Length == 0) return null;
+
+        var refVerts = referenceMesh.vertices;
+        var refNormals = referenceMesh.normals;
+        if (refVerts.Length == 0 || refNormals.Length != refVerts.Length) return null;
+
+        // referenceShape weight=100 を再現する
+        // 指定された場合は必ず存在することを期待。無ければ「肌が縮む前の状態」で push してしまい
+        // 過剰補正になるため、warn を出して null 返却で安全側に倒す。
+        if (!string.IsNullOrEmpty(referenceShape))
+        {
+            int idx = referenceMesh.GetBlendShapeIndex(referenceShape);
+            if (idx < 0 || referenceMesh.GetBlendShapeFrameCount(idx) == 0)
+            {
+                PatchLogger.LogWarning(
+                    $"[{logTag}] reference blendShape '{referenceShape}' が見つからない (referenceMesh={referenceMesh.name})、補正スキップ");
+                return null;
+            }
+            int lastFrame = referenceMesh.GetBlendShapeFrameCount(idx) - 1;
+            var dv = new Vector3[refVerts.Length];
+            var dn = new Vector3[refVerts.Length];
+            var dt = new Vector3[refVerts.Length];
+            referenceMesh.GetBlendShapeFrameVertices(idx, lastFrame, dv, dn, dt);
+            for (int i = 0; i < refVerts.Length; i++)
+            {
+                refVerts[i] += dv[i];
+                // base + dn の合成。零ベクトル化した場合 normalized は (0,0,0) を返し、
+                // 後段の dot は 0 → push 候補となるが、+sn*0 = s で v が s に吸い寄せられるだけ。
+                // dn が極端に逆向きの場合は invertGuard でスキップされる。
+                refNormals[i] = (refNormals[i] + dn[i]).normalized;
+            }
+        }
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        long gridStart = sw.ElapsedMilliseconds;
+        var grid = new SpatialGridIndex(refVerts);
+        long gridMs = sw.ElapsedMilliseconds - gridStart;
+
+        var newMesh = Object.Instantiate(donorMesh);
+        newMesh.name = donorMesh.name + "_offset";
+
+        // 内側に深く食い込んでいる頂点（reference 法線が逆向き、または別パーツの裏面に
+        // 最近傍が引っかかった等）を「外側へ反転 push」して破綻させないためのガード。
+        // signed_d < -invertGuardMul * minOffset の場合は補正スキップ。
+        const float invertGuardMul = 10f;
+        float invertGuard = -minOffset * invertGuardMul;
+
+        int pushed = 0;
+        int skippedInverted = 0;
+        float maxPushDist = 0f;
+        long nearestStart = sw.ElapsedMilliseconds;
+        for (int i = 0; i < donorVerts.Length; i++)
+        {
+            var v = donorVerts[i];
+            int j = grid.FindNearest(v);
+            var s = refVerts[j];
+            var sn = refNormals[j];
+
+            float signedD = Vector3.Dot(v - s, sn);
+            if (signedD < invertGuard)
+            {
+                skippedInverted++;
+                continue;
+            }
+            if (signedD < minOffset)
+            {
+                // sn 軸方向にだけ動かす（tangent 成分を保持）。
+                // s + sn * minOffset で「最近傍点の真上にスナップ」すると tangent 位置を失って
+                // 遠い場所にワープし mesh が崩れる。v + sn * delta なら元の頂点位置からの
+                // 最小限の押し出しになり、トポロジーが保たれる。
+                float delta = minOffset - signedD;
+                donorVerts[i] = v + sn * delta;
+                if (delta > maxPushDist) maxPushDist = delta;
+                pushed++;
+            }
+        }
+        long nearestMs = sw.ElapsedMilliseconds - nearestStart;
+
+        newMesh.vertices = donorVerts;
+        newMesh.RecalculateNormals();
+        newMesh.RecalculateBounds();
+
+        sw.Stop();
+        PatchLogger.LogInfo(
+            $"[{logTag}] surface offset 適用: target={donorMesh.name} verts={donorVerts.Length} pushed={pushed} skippedInv={skippedInverted} maxPush={maxPushDist:F4}m offset={minOffset:F4}m grid={gridMs}ms nearest={nearestMs}ms total={sw.ElapsedMilliseconds}ms");
+
+        if (pushed == 0)
+        {
+            Object.Destroy(newMesh);
+            return null;
+        }
+
+        return newMesh;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SpatialGridIndex.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SpatialGridIndex.cs
@@ -95,6 +95,72 @@ internal sealed class SpatialGridIndex
         return bestIdx;
     }
 
+    /// <summary>
+    /// クエリ点 q に最も近い K 個の登録点 index を距離昇順で results に追加する。
+    /// 登録点数 &lt; K の場合は実数分のみ追加。既存の results は呼出し側で必要なら Clear する。
+    /// </summary>
+    public void FindKNearest(Vector3 q, int k, List<int> results)
+    {
+        if (_points.Length == 0 || k <= 0) return;
+
+        int qx = (int)Mathf.Floor((q.x - _origin.x) * _invCellSize);
+        int qy = (int)Mathf.Floor((q.y - _origin.y) * _invCellSize);
+        int qz = (int)Mathf.Floor((q.z - _origin.z) * _invCellSize);
+
+        // best-K: 距離昇順の固定長バッファ。bestSq[0] が最近、bestSq[k-1] が最遠。
+        var bestSq = new float[k];
+        var bestIdx = new int[k];
+        for (int i = 0; i < k; i++) { bestSq[i] = float.MaxValue; bestIdx[i] = -1; }
+        int filled = 0;
+
+        const int MaxRadius = 1024;
+        for (int r = 0; r <= MaxRadius; r++)
+        {
+            ScanShellK(qx, qy, qz, r, q, bestSq, bestIdx, ref filled, k);
+            if (filled >= k)
+            {
+                float worstDist = Mathf.Sqrt(bestSq[k - 1]);
+                if (r * _cellSize >= worstDist) break;
+            }
+        }
+
+        for (int i = 0; i < k; i++)
+        {
+            if (bestIdx[i] >= 0) results.Add(bestIdx[i]);
+        }
+    }
+
+    /// <summary>
+    /// クエリ点 q から半径 radius (m) 以内の登録点 index を results に追加する。
+    /// 既存の results はクリアしない（呼出し側で必要なら Clear する）。
+    /// </summary>
+    public void FindWithinRadius(Vector3 q, float radius, List<int> results)
+    {
+        if (_points.Length == 0 || radius <= 0f) return;
+
+        int qx = (int)Mathf.Floor((q.x - _origin.x) * _invCellSize);
+        int qy = (int)Mathf.Floor((q.y - _origin.y) * _invCellSize);
+        int qz = (int)Mathf.Floor((q.z - _origin.z) * _invCellSize);
+
+        int cellRadius = Mathf.Max(1, (int)Mathf.Ceil(radius * _invCellSize));
+        float radSq = radius * radius;
+
+        for (int dx = -cellRadius; dx <= cellRadius; dx++)
+        for (int dy = -cellRadius; dy <= cellRadius; dy++)
+        for (int dz = -cellRadius; dz <= cellRadius; dz++)
+        {
+            if (!_cells.TryGetValue(PackKey(qx + dx, qy + dy, qz + dz), out var list)) continue;
+            for (int i = 0; i < list.Count; i++)
+            {
+                int idx = list[i];
+                var p = _points[idx];
+                float ex = p.x - q.x, ey = p.y - q.y, ez = p.z - q.z;
+                float sq = ex * ex + ey * ey + ez * ez;
+                if (sq <= radSq) results.Add(idx);
+            }
+        }
+    }
+
     private void ScanShell(int cx, int cy, int cz, int r, Vector3 q, ref int bestIdx, ref float bestSq)
     {
         if (r == 0)
@@ -114,6 +180,53 @@ internal sealed class SpatialGridIndex
             if (az > m) m = az;
             if (m != r) continue; // 内側は前のシェルで走査済み
             ScanCell(cx + dx, cy + dy, cz + dz, q, ref bestIdx, ref bestSq);
+        }
+    }
+
+    private void ScanShellK(int cx, int cy, int cz, int r, Vector3 q, float[] bestSq, int[] bestIdx, ref int filled, int k)
+    {
+        if (r == 0)
+        {
+            ScanCellK(cx, cy, cz, q, bestSq, bestIdx, ref filled, k);
+            return;
+        }
+        for (int dx = -r; dx <= r; dx++)
+        for (int dy = -r; dy <= r; dy++)
+        for (int dz = -r; dz <= r; dz++)
+        {
+            int ax = dx < 0 ? -dx : dx;
+            int ay = dy < 0 ? -dy : dy;
+            int az = dz < 0 ? -dz : dz;
+            int m = ax > ay ? ax : ay;
+            if (az > m) m = az;
+            if (m != r) continue;
+            ScanCellK(cx + dx, cy + dy, cz + dz, q, bestSq, bestIdx, ref filled, k);
+        }
+    }
+
+    private void ScanCellK(int cx, int cy, int cz, Vector3 q, float[] bestSq, int[] bestIdx, ref int filled, int k)
+    {
+        if (!_cells.TryGetValue(PackKey(cx, cy, cz), out var list)) return;
+        for (int i = 0; i < list.Count; i++)
+        {
+            int idx = list[i];
+            var p = _points[idx];
+            float ex = p.x - q.x, ey = p.y - q.y, ez = p.z - q.z;
+            float sq = ex * ex + ey * ey + ez * ez;
+            // bestSq[k-1] (現在の最遠) を超えるなら無視
+            if (sq >= bestSq[k - 1]) continue;
+            // 挿入位置を二分/線形探索（k は小さいので線形）
+            int pos = k - 1;
+            while (pos > 0 && bestSq[pos - 1] > sq) pos--;
+            // [pos .. k-2] を 1 つ右にシフト
+            for (int j = k - 1; j > pos; j--)
+            {
+                bestSq[j] = bestSq[j - 1];
+                bestIdx[j] = bestIdx[j - 1];
+            }
+            bestSq[pos] = sq;
+            bestIdx[pos] = idx;
+            if (filled < k) filled++;
         }
     }
 

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SpatialGridIndex.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SpatialGridIndex.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// 静的な点群に対する nearest-neighbor 検索用の均一空間グリッド索引。
+/// ドナー頂点群（数千〜2万点）を想定。
+/// </summary>
+internal sealed class SpatialGridIndex
+{
+    private readonly Vector3[] _points;
+    private readonly Vector3 _origin;
+    private readonly float _cellSize;
+    private readonly float _invCellSize;
+    private readonly Dictionary<long, List<int>> _cells;
+
+    // セル座標を long にパックする際のビット幅（各軸 21bit / 符号ビット 1）
+    private const int Bits = 21;
+    private const int Bias = 1 << (Bits - 1); // 1<<20 で負の座標をオフセット
+
+    public SpatialGridIndex(Vector3[] points)
+    {
+        _points = points;
+
+        // 空の点群は非エラーとして扱う（FindNearest は -1 を返す）
+        if (points.Length == 0)
+        {
+            _origin = Vector3.zero;
+            _cellSize = 1f;
+            _invCellSize = 1f;
+            _cells = new Dictionary<long, List<int>>();
+            return;
+        }
+
+        // 1. AABB
+        Vector3 min = points[0], max = points[0];
+        for (int i = 1; i < points.Length; i++)
+        {
+            var p = points[i];
+            if (p.x < min.x) min.x = p.x; else if (p.x > max.x) max.x = p.x;
+            if (p.y < min.y) min.y = p.y; else if (p.y > max.y) max.y = p.y;
+            if (p.z < min.z) min.z = p.z; else if (p.z > max.z) max.z = p.z;
+        }
+        _origin = min;
+
+        // 2. cellSize: AABB 対角 / cbrt(N)
+        float diag = (max - min).magnitude;
+        if (diag < 1e-6f) diag = 1e-6f;
+        float n = Mathf.Pow(Mathf.Max(points.Length, 1), 1f / 3f);
+        _cellSize = Mathf.Max(diag / Mathf.Max(n, 1f), 1e-5f);
+        _invCellSize = 1f / _cellSize;
+
+        // 3. ビン詰め
+        _cells = new Dictionary<long, List<int>>(points.Length);
+        for (int i = 0; i < points.Length; i++)
+        {
+            long key = CellKey(points[i]);
+            if (!_cells.TryGetValue(key, out var list))
+            {
+                list = new List<int>(4);
+                _cells[key] = list;
+            }
+            list.Add(i);
+        }
+    }
+
+    /// <summary>
+    /// クエリ点 q に最も近い登録点の index を返す。点群が空の場合 -1。
+    /// </summary>
+    public int FindNearest(Vector3 q)
+    {
+        if (_points.Length == 0) return -1;
+
+        int qx = (int)Mathf.Floor((q.x - _origin.x) * _invCellSize);
+        int qy = (int)Mathf.Floor((q.y - _origin.y) * _invCellSize);
+        int qz = (int)Mathf.Floor((q.z - _origin.z) * _invCellSize);
+
+        int bestIdx = -1;
+        float bestSq = float.MaxValue;
+
+        const int MaxRadius = 1024; // セーフティ
+        for (int r = 0; r <= MaxRadius; r++)
+        {
+            ScanShell(qx, qy, qz, r, q, ref bestIdx, ref bestSq);
+
+            if (bestIdx >= 0)
+            {
+                // 現在の半径 r より外側のシェルにある点は、距離が少なくとも r*cellSize 以上ある。
+                // best を超える可能性が無くなったら打ち切る。
+                float bestDist = Mathf.Sqrt(bestSq);
+                if (r * _cellSize >= bestDist) return bestIdx;
+            }
+        }
+        return bestIdx;
+    }
+
+    private void ScanShell(int cx, int cy, int cz, int r, Vector3 q, ref int bestIdx, ref float bestSq)
+    {
+        if (r == 0)
+        {
+            ScanCell(cx, cy, cz, q, ref bestIdx, ref bestSq);
+            return;
+        }
+        // シェル: max(|dx|,|dy|,|dz|) == r となる立方体の表面のみ
+        for (int dx = -r; dx <= r; dx++)
+        for (int dy = -r; dy <= r; dy++)
+        for (int dz = -r; dz <= r; dz++)
+        {
+            int ax = dx < 0 ? -dx : dx;
+            int ay = dy < 0 ? -dy : dy;
+            int az = dz < 0 ? -dz : dz;
+            int m = ax > ay ? ax : ay;
+            if (az > m) m = az;
+            if (m != r) continue; // 内側は前のシェルで走査済み
+            ScanCell(cx + dx, cy + dy, cz + dz, q, ref bestIdx, ref bestSq);
+        }
+    }
+
+    private void ScanCell(int cx, int cy, int cz, Vector3 q, ref int bestIdx, ref float bestSq)
+    {
+        if (!_cells.TryGetValue(PackKey(cx, cy, cz), out var list)) return;
+        for (int i = 0; i < list.Count; i++)
+        {
+            int idx = list[i];
+            var p = _points[idx];
+            float ex = p.x - q.x, ey = p.y - q.y, ez = p.z - q.z;
+            float sq = ex * ex + ey * ey + ez * ez;
+            if (sq < bestSq) { bestSq = sq; bestIdx = idx; }
+        }
+    }
+
+    private long CellKey(Vector3 p)
+    {
+        int cx = (int)Mathf.Floor((p.x - _origin.x) * _invCellSize);
+        int cy = (int)Mathf.Floor((p.y - _origin.y) * _invCellSize);
+        int cz = (int)Mathf.Floor((p.z - _origin.z) * _invCellSize);
+        return PackKey(cx, cy, cz);
+    }
+
+    private static long PackKey(int cx, int cy, int cz)
+    {
+        // [-Bias, Bias) を超える cx はキー衝突を起こすのでクランプする。
+        // 退化メッシュ（cellSize 極小）+ クエリ点が AABB 外側で発生し得るため。
+        // 遠方点を端セルに集約しても、最近傍候補ではないので正しさは保たれる。
+        return ClampAndBias(cx)
+             | (ClampAndBias(cy) << Bits)
+             | (ClampAndBias(cz) << (Bits * 2));
+    }
+
+    private static long ClampAndBias(int c)
+    {
+        const int Max = (1 << (Bits - 1)) - 1; // 2^20 - 1
+        const int Min = -(1 << (Bits - 1));    // -2^20
+        if (c > Max) c = Max;
+        else if (c < Min) c = Min;
+        return (long)(c + Bias); // [0, 2^21)
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/StockingsDonorLoader.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/StockingsDonorLoader.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BunnyGarden2FixMod.Utils;
+using GB;
+using GB.Game;
+using GB.Scene;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.SceneManagement;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// 水着×ストッキング用に、全 6 キャラの Uniform prefab から mesh_stockings SMR を
+/// 起動時にプリロードしてキャラ別キャッシュする。
+///
+/// Addressables.LoadAssetAsync&lt;GameObject&gt; で生 asset を取得する。
+/// InstantiateAsync 経路ではランタイム処理により mesh_stockings が失われる
+/// （costume が Uniform でも mesh_skin_lower_foot 構造に書き換わる）ため不可。
+///
+/// 用途: SwimWearStockingPatch が水着時の ApplyStocking 同期処理で
+/// キャラ固有の donor SMR を取り出して bone リマップして注入する。
+/// </summary>
+public class StockingsDonorLoader : MonoBehaviour
+{
+    private static readonly Dictionary<int, SkinnedMeshRenderer> s_stockingsMesh = new();
+    // Uniform の mesh_skin_lower（skin_stocking / skin_stocking_lower blendShape 入り、verts=2193/2234）
+    // 水着の mesh_skin_lower（shapes=0, verts=半分）を差し替えてめり込み防止する用
+    private static readonly Dictionary<int, SkinnedMeshRenderer> s_lowerMesh = new();
+    // handle は保持し続ける（mesh 参照を維持するため Release しない）
+    private static readonly List<AsyncOperationHandle<GameObject>> s_assetHandles = new();
+    // type 1..4 のストッキングマテリアル（[0] 未使用）
+    private static readonly Material[] s_materials = new Material[5];
+
+    private static readonly string[] s_materialPaths = new string[5]
+    {
+        null,
+        "Character/PC00_Common/Materials/stockings/m_stockings.mat",
+        "Character/PC00_Common/Materials/stockings/m_stockings_white.mat",
+        "Character/PC00_Common/Materials/stockings/m_fishnetstockings.mat",
+        "Character/PC00_Common/Materials/stockings/m_fishnetstockings_white.mat",
+    };
+
+    public static bool IsReady { get; private set; }
+
+    public static void Initialize(GameObject parent)
+    {
+        parent.AddComponent<StockingsDonorLoader>();
+    }
+
+    private void OnEnable()
+    {
+        SceneManager.sceneUnloaded += OnSceneUnloaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneUnloaded -= OnSceneUnloaded;
+    }
+
+    private static void OnSceneUnloaded(Scene scene)
+    {
+        // donor asset は永続保持（Release しない）。水着キャラ配下に注入・移植した mesh は
+        // シーン破棄で fake-null 化するため SwimWearStockingPatch 側のキャッシュを一掃する。
+        SwimWearStockingPatch.OnSceneUnloaded();
+    }
+
+    public static bool TryGetDonor(CharID id, out SkinnedMeshRenderer smr)
+    {
+        return s_stockingsMesh.TryGetValue((int)id, out smr) && smr != null;
+    }
+
+    public static bool TryGetLowerDonor(CharID id, out SkinnedMeshRenderer smr)
+    {
+        return s_lowerMesh.TryGetValue((int)id, out smr) && smr != null;
+    }
+
+    public static Material GetMaterial(int type)
+    {
+        if (type >= 1 && type <= 4) return s_materials[type];
+        return null;
+    }
+
+    private IEnumerator Start()
+    {
+        yield return new WaitUntil(() => GBSystem.Instance != null && GBSystem.Instance.RefSaveData() != null);
+
+        for (int i = 0; i < 6; i++)
+        {
+            var id = (CharID)i;
+            var key = CharacterHandle.COSTUME_FILE_PATH(id, CostumeType.Uniform);
+            var h = Addressables.LoadAssetAsync<GameObject>(key);
+            yield return h;
+
+            if (!h.IsValid() || h.Result == null)
+            {
+                PatchLogger.LogWarning($"[StockingsDonorLoader] asset ロード失敗: {key}");
+                if (h.IsValid()) Addressables.Release(h);
+                continue;
+            }
+
+            var smr = h.Result.GetComponentsInChildren<SkinnedMeshRenderer>(true)
+                .FirstOrDefault(m => m.name == "mesh_stockings");
+
+            if (smr == null || smr.sharedMesh == null)
+            {
+                PatchLogger.LogWarning($"[StockingsDonorLoader] mesh_stockings 未検出: {key}");
+                Addressables.Release(h);
+                continue;
+            }
+
+            s_stockingsMesh[i] = smr;
+
+            // mesh_skin_lower も同じ asset からキャッシュ
+            var lower = h.Result.GetComponentsInChildren<SkinnedMeshRenderer>(true)
+                .FirstOrDefault(m => m.name == "mesh_skin_lower");
+            if (lower != null && lower.sharedMesh != null)
+            {
+                s_lowerMesh[i] = lower;
+                PatchLogger.LogInfo($"[StockingsDonorLoader] {id} Uniform mesh_skin_lower キャッシュ (verts={lower.sharedMesh.vertexCount}, shapes={lower.sharedMesh.blendShapeCount})");
+            }
+
+            s_assetHandles.Add(h);
+            PatchLogger.LogInfo($"[StockingsDonorLoader] {id} Uniform mesh_stockings キャッシュ (verts={smr.sharedMesh.vertexCount}, bones={smr.bones?.Length ?? 0})");
+        }
+
+        for (int t = 1; t <= 4; t++)
+        {
+            var h = Addressables.LoadAssetAsync<Material>(s_materialPaths[t]);
+            yield return h;
+            if (h.IsValid() && h.Result != null)
+            {
+                s_materials[t] = h.Result;
+                PatchLogger.LogInfo($"[StockingsDonorLoader] stocking material type {t} プリロード完了");
+            }
+            else
+            {
+                PatchLogger.LogWarning($"[StockingsDonorLoader] material type {t} ロード失敗: {s_materialPaths[t]}");
+            }
+        }
+
+        IsReady = true;
+        PatchLogger.LogInfo($"[StockingsDonorLoader] Ready (donors={s_stockingsMesh.Count}/6)");
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
@@ -49,9 +49,18 @@ public static class SwimWearStockingPatch
 
     private static readonly Dictionary<int, SwimwearBackup> s_backups = new();
 
-    // (swimMeshInstanceId, charId, isKneeSocks) → nearest-neighbor 移植済みメッシュ
-    // isKneeSocks=true の場合は skin_kneehigh ドナーも含めて移植するため、キーに含める
-    private static readonly Dictionary<(int, int, bool), Mesh> s_transplantedCache = new();
+    // (swimMeshInstanceId, charId, isKneeSocks, shapeFalloffQ) → nearest-neighbor 移植済みメッシュ
+    // isKneeSocks=true の場合は skin_kneehigh ドナーも含めて移植する。
+    // shapeFalloffQ は ConfigStockingShapeFalloffRadius を 0.1mm 量子化した値で、
+    // skin_stocking 系 blendShape の per-vertex フェード量に応じて別キャッシュを保持する。
+    private static readonly Dictionary<(int, int, bool, int), Mesh> s_transplantedCache = new();
+
+    // (donorMeshInstanceId, swimSkinMeshInstanceId, isKneeSocks, x_q, y_q, f_q)
+    // → 食い込み解消済みの (donor stocking, swim skin) ペア。MeshPenetrationResolver の出力をキャッシュ。
+    private static readonly Dictionary<(int, int, bool, int, int, int), (Mesh donor, Mesh skin)> s_resolvedCache = new();
+
+    // resolve 適用済み Mesh の InstanceID。SMR が既に補正済 mesh を持っている場合の二重補正防止。
+    private static readonly System.Collections.Generic.HashSet<int> s_resolvedAppliedIds = new();
 
     static bool Prepare()
     {
@@ -77,8 +86,48 @@ public static class SwimWearStockingPatch
             }
         }
         s_transplantedCache.Clear();
+
+        int resolvedDestroyed = 0;
+        foreach (var pair in s_resolvedCache.Values)
+        {
+            if (pair.donor != null) { Object.Destroy(pair.donor); resolvedDestroyed++; }
+            if (pair.skin != null) { Object.Destroy(pair.skin); resolvedDestroyed++; }
+        }
+        s_resolvedCache.Clear();
+        s_resolvedAppliedIds.Clear();
+
+        // s_backups.LowerOriginalMesh / LowerFootOriginalMesh はゲーム本体所有の sharedMesh のため
+        // Destroy せず参照のみクリアする（Destroy するとゲーム側のメッシュが消えて破綻する）。
         s_backups.Clear();
-        PatchLogger.LogInfo($"[SwimWearStockingPatch] シーンアンロード: transplanted mesh {destroyed} 件破棄、キャッシュクリア");
+        PatchLogger.LogInfo($"[SwimWearStockingPatch] シーンアンロード: transplanted {destroyed} 件、resolved {resolvedDestroyed} 件破棄");
+    }
+
+    /// <summary>
+    /// チューニングスライダー等から ConfigStockingOffset/SkinShrink/FalloffRadius を変更した直後に呼び、
+    /// 次の env.ApplyStockings() で食い込み解消が新パラメータで再構築されるよう状態を整える。
+    ///
+    /// 復元手順:
+    ///   1. swim skin の sharedMesh を backup originalMesh に戻す（次の TransplantInto が
+    ///      vanilla skin から transplanted を構築できるようにする）
+    ///   2. s_resolvedAppliedIds をクリア（ApplyPenetrationResolve の二重補正防止 early-return を解除）
+    ///
+    /// s_resolvedCache / s_transplantedCache は破棄しない:
+    ///   - resolvedCache キーには量子化パラメータが含まれるので、別パラメータでは別エントリが作られる。
+    ///     同一パラメータに戻したときの再ヒットを許容するためそのまま保持する（OnSceneUnloaded で一括破棄）。
+    ///   - 注入 stockings smr の sharedMesh は ApplyStockingSync 冒頭で donor.sharedMesh に
+    ///     必ず差し戻されるため、ここで触らなくて良い。
+    /// </summary>
+    internal static void InvalidateForReapply(CharID id)
+    {
+        int key = (int)id;
+        if (s_backups.TryGetValue(key, out var backup))
+        {
+            if (backup.LowerSmr != null && backup.LowerOriginalMesh != null)
+                backup.LowerSmr.sharedMesh = backup.LowerOriginalMesh;
+            if (backup.LowerFootSmr != null && backup.LowerFootOriginalMesh != null)
+                backup.LowerFootSmr.sharedMesh = backup.LowerFootOriginalMesh;
+        }
+        s_resolvedAppliedIds.Clear();
     }
 
     private static bool Prefix(CharacterHandle __instance, int __0)
@@ -228,8 +277,62 @@ public static class SwimWearStockingPatch
 
         ApplyBlendShapeTransplant(handle, chara, renderers, 100f, isKneeSocks);
 
+        // donor stocking と swim skin の食い込みを 1 パスで検出し、両側に push して z-fighting を解消
+        var swimLowerForRef = renderers.FirstOrDefault(m => m.name == "mesh_skin_lower");
+        ApplyPenetrationResolve(smr, swimLowerForRef, renderers, isKneeSocks);
+
         PatchLogger.LogInfo($"[SwimWearStockingPatch] 適用: {handle.GetCharID()} override={overrideType} knee={isKneeSocks} created={created} meshVerts={targetMesh.vertexCount} bones={smr.bones?.Length ?? 0}");
         return true;
+    }
+
+    /// <summary>
+    /// donor stocking と swim skin の食い込みを 1 パスで検出し、両側へ押し出して解消する。
+    /// 食い込み点でのみ skin 頂点を内側へ push するため、一様 shrink と違い境界で段差が出ない。
+    /// 結果ペアは s_resolvedCache にキャッシュ。
+    /// </summary>
+    private static void ApplyPenetrationResolve(SkinnedMeshRenderer stockingsSmr, SkinnedMeshRenderer swimLower, SkinnedMeshRenderer[] renderers, bool isKneeSocks)
+    {
+        if (stockingsSmr == null || stockingsSmr.sharedMesh == null) return;
+        if (swimLower == null || swimLower.sharedMesh == null) return;
+
+        // ニーハイは形状・カバー範囲が異なり本補正の前提（尻まわりの z-fighting）と合わないため対象外
+        if (isKneeSocks) return;
+
+        float minOffset = Plugin.ConfigStockingOffset?.Value ?? 0f;
+        float skinPushAmount = Plugin.ConfigStockingSkinShrink?.Value ?? 0f;
+        float falloffRadius = Plugin.ConfigStockingSkinFalloffRadius?.Value ?? 0f;
+        if (minOffset <= 0f && skinPushAmount <= 0f) return;
+
+        var currentDonor = stockingsSmr.sharedMesh;
+        var currentSkin = swimLower.sharedMesh;
+
+        // 二重補正防止
+        if (s_resolvedAppliedIds.Contains(currentDonor.GetInstanceID())) return;
+
+        // 量子化キー: 0.1mm precision (max 0.01m → 100、int で十分収まる)
+        int xQ = Mathf.RoundToInt(minOffset * 10_000f);
+        int yQ = Mathf.RoundToInt(skinPushAmount * 10_000f);
+        int fQ = Mathf.RoundToInt(falloffRadius * 10_000f);
+        var cacheKey = (currentDonor.GetInstanceID(), currentSkin.GetInstanceID(), isKneeSocks, xQ, yQ, fQ);
+
+        if (!s_resolvedCache.TryGetValue(cacheKey, out var pair))
+        {
+            var skinAnchorVerts = CollectShrinkAnchorVerts(renderers);
+
+            pair = MeshPenetrationResolver.Resolve(
+                currentDonor, currentSkin,
+                "blendShape_skin_lower.skin_stocking",
+                minOffset, skinPushAmount,
+                skinAnchorVerts, falloffRadius,
+                "SwimWearStockingPatch");
+
+            s_resolvedCache[cacheKey] = pair;
+            if (pair.donor != null) s_resolvedAppliedIds.Add(pair.donor.GetInstanceID());
+            if (pair.skin != null) s_resolvedAppliedIds.Add(pair.skin.GetInstanceID());
+        }
+
+        if (pair.donor != null) stockingsSmr.sharedMesh = pair.donor;
+        if (pair.skin != null) swimLower.sharedMesh = pair.skin;
     }
 
     private static void ApplyBlendShapeTransplant(CharacterHandle handle, GameObject chara, SkinnedMeshRenderer[] renderers, float shrinkWeight, bool isKneeSocks)
@@ -252,16 +355,61 @@ public static class SwimWearStockingPatch
             s_backups[key] = backup;
         }
 
-        TransplantInto(swimLower, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, ref backup.LowerSmr, ref backup.LowerOriginalMesh);
-        TransplantInto(swimLowerFoot, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, ref backup.LowerFootSmr, ref backup.LowerFootOriginalMesh);
+        // skin_stocking 系 blendShape の per-vertex フェード設定（KneeSocks では skin_kneehigh が
+        // 主体になるためスキップ）
+        Vector3[] shapeAnchorVerts = null;
+        float shapeFalloffRadius = 0f;
+        if (!isKneeSocks)
+        {
+            shapeFalloffRadius = Plugin.ConfigStockingShapeFalloffRadius?.Value ?? 0f;
+            if (shapeFalloffRadius > 0f) shapeAnchorVerts = CollectShrinkAnchorVerts(renderers);
+        }
+
+        TransplantInto(swimLower, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, shapeAnchorVerts, shapeFalloffRadius, ref backup.LowerSmr, ref backup.LowerOriginalMesh);
+        TransplantInto(swimLowerFoot, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, shapeAnchorVerts, shapeFalloffRadius, ref backup.LowerFootSmr, ref backup.LowerFootOriginalMesh);
+    }
+
+    private static readonly System.Collections.Generic.HashSet<string> s_shrinkTargetNames = new()
+    {
+        "mesh_skin_lower",
+        "mesh_skin_lower_foot",
+    };
+
+    /// <summary>
+    /// shrink 対象（mesh_skin_lower / mesh_skin_lower_foot）以外の skin 系メッシュの頂点を集める。
+    /// 同一キャラ配下で sibling SMR は共通の mesh-local 座標系を持つ前提で、頂点を直接連結する。
+    /// </summary>
+    private static Vector3[] CollectShrinkAnchorVerts(SkinnedMeshRenderer[] renderers)
+    {
+        var list = new System.Collections.Generic.List<Vector3>();
+        foreach (var r in renderers)
+        {
+            if (r == null || r.sharedMesh == null) continue;
+            if (!r.name.StartsWith("mesh_skin_")) continue;
+            if (s_shrinkTargetNames.Contains(r.name)) continue;
+            list.AddRange(r.sharedMesh.vertices);
+        }
+        return list.ToArray();
     }
 
     private static void TransplantInto(SkinnedMeshRenderer target, Mesh donorMesh, int charKey, float shrinkWeight, bool isKneeSocks,
+        Vector3[] shapeAnchorVerts, float shapeFalloffRadius,
         ref SkinnedMeshRenderer backupSmr, ref Mesh backupOriginal)
     {
         if (target == null || target.sharedMesh == null) return;
 
-        var cacheKey = (target.sharedMesh.GetInstanceID(), charKey, isKneeSocks);
+        // 過去の override から残っている transplanted/resolved mesh を vanilla に戻す。
+        // 戻さないと cache key が「以前の transplanted ID」になり、その mesh を base に
+        // 二重 transplant してしまう（例: ニーハイ→パンスト時に skin_kneehigh delta が
+        // 残った状態の上に skin_stocking 系を載せてしまい、Resolve の reference 表面が狂う）。
+        if (backupOriginal != null && target.sharedMesh != backupOriginal)
+        {
+            target.sharedMesh = backupOriginal;
+        }
+
+        // shape falloff 量子化キー (0.1mm 精度, max 0.01m → 100)
+        int shapeFalloffQ = Mathf.RoundToInt(shapeFalloffRadius * 10_000f);
+        var cacheKey = (target.sharedMesh.GetInstanceID(), charKey, isKneeSocks, shapeFalloffQ);
 
         if (!s_transplantedCache.TryGetValue(cacheKey, out var transplanted) || transplanted == null)
         {
@@ -269,6 +417,13 @@ public static class SwimWearStockingPatch
             // ここでは target.sharedMesh が元の mesh（swim 生）であることを期待
             transplanted = BuildTransplantedMesh(target.sharedMesh, donorMesh, isKneeSocks);
             if (transplanted == null) return;
+
+            // skin_stocking 系 blendShape を per-vertex でフェード（mesh_skin_upper 等の境界で段差を解消）
+            if (shapeFalloffRadius > 0f && shapeAnchorVerts != null && !isKneeSocks)
+            {
+                BlendShapeFalloffApplier.Apply(transplanted, s_transplantShapeNames, shapeAnchorVerts, shapeFalloffRadius, "SwimWearStockingPatch");
+            }
+
             s_transplantedCache[cacheKey] = transplanted;
         }
 
@@ -312,7 +467,7 @@ public static class SwimWearStockingPatch
     {
         if (!isKneeSocks)
         {
-            // isKneeSocks=false: 既存どおり単一ドナー（Uniform）から skin_stocking 系のみ移植
+            // isKneeSocks=false: 単一ドナー（Uniform）から skin_stocking 系のみ移植
             return MeshBlendShapeTransplanter.Transplant(targetMesh, donorMesh, s_transplantShapeNames, "SwimWearStockingPatch");
         }
 
@@ -385,7 +540,7 @@ public static class SwimWearStockingPatch
             target.rootBone = fallback;
 
         if (missing > 0)
-            PatchLogger.LogWarning($"[SwimWearStockingPatch] bone 未対応 {missing}/{src.Length}");
+            PatchLogger.LogInfo($"[SwimWearStockingPatch] bone 未対応 {missing}/{src.Length}");
     }
 
     /// <summary>
@@ -404,7 +559,7 @@ public static class SwimWearStockingPatch
                 collisions++;
         }
         if (collisions > 0)
-            PatchLogger.LogWarning($"[SwimWearStockingPatch] bone 名衝突 {collisions} 件を先勝ちで無視 (chara={chara.name})");
+            PatchLogger.LogInfo($"[SwimWearStockingPatch] bone 名衝突 {collisions} 件を先勝ちで無視 (chara={chara.name})");
         return dict;
     }
 }

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
@@ -1,0 +1,410 @@
+using System.Collections.Generic;
+using System.Linq;
+using BunnyGarden2FixMod.Utils;
+using GB.Game;
+using GB.Scene;
+using HarmonyLib;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches.CostumeChanger;
+
+/// <summary>
+/// 水着コスチューム着用中、CharacterHandle.ApplyStocking は IsDisableStocking で早期 return し
+/// ストッキングが一切適用されない。本パッチは Prefix で水着を検出し、async をスキップして
+/// 同期的にストッキングを適用／解除する。
+///
+/// 実装:
+///   1. StockingsDonorLoader が Uniform prefab からキャラ別に mesh_stockings / mesh_skin_lower をキャッシュ
+///   2. 水着キャラ配下に新 GameObject "mesh_stockings" を注入（bone リマップ）
+///   3. 水着の mesh_skin_lower / mesh_skin_lower_foot に blendShape の delta を nearest-neighbor で移植
+///      - Uniform donor mesh_skin_lower の skin_stocking / skin_socks / skin_stocking_lower blendShape デルタを
+///        swim 各頂点に対して「Uniform 側の最近傍頂点のデルタ」として転写する
+///      - 頂点数が違っても適用できる（Uniform 2193 → swim 1238〜1304 や 892〜946）
+///      - mesh 構造は swim のまま保持。material/UV/外形シルエットが崩れない
+///   4. blendShape weight を 100 に設定 → 脚が少し細くなり stocking にフィット
+///
+/// 順序: HarmonyPriority.First で他の ApplyStocking Prefix より先に走らせ、水着時は return false で打ち切る。
+/// </summary>
+[HarmonyPatch(typeof(CharacterHandle), nameof(CharacterHandle.ApplyStocking))]
+[HarmonyPriority(Priority.First)]
+public static class SwimWearStockingPatch
+{
+    private const string InjectedName = "mesh_stockings";
+
+    private static readonly string[] s_transplantShapeNames = new[]
+    {
+        "blendShape_skin_lower.skin_stocking",
+        "blendShape_skin_lower.skin_socks",
+        "blendShape_skin_lower.skin_stocking_lower",
+    };
+
+    /// <summary>水着キャラの lower 系メッシュを差し替え前に保存。</summary>
+    private class SwimwearBackup
+    {
+        public SkinnedMeshRenderer LowerSmr;
+        public Mesh LowerOriginalMesh;
+        public SkinnedMeshRenderer LowerFootSmr;
+        public Mesh LowerFootOriginalMesh;
+    }
+
+    private static readonly Dictionary<int, SwimwearBackup> s_backups = new();
+
+    // (swimMeshInstanceId, charId, isKneeSocks) → nearest-neighbor 移植済みメッシュ
+    // isKneeSocks=true の場合は skin_kneehigh ドナーも含めて移植するため、キーに含める
+    private static readonly Dictionary<(int, int, bool), Mesh> s_transplantedCache = new();
+
+    static bool Prepare()
+    {
+        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        if (enabled) PatchLogger.LogInfo("[SwimWearStockingPatch] 適用");
+        return enabled;
+    }
+
+    /// <summary>
+    /// シーンアンロード時にキャッシュを一掃する。StockingsDonorLoader MonoBehaviour 側から呼ばれる。
+    /// 破棄済み SMR 参照を持ち越すと次シーンでの復元時に fake-null 例外 / InstanceID 再利用による
+    /// 誤 hit が発生するため、毎シーンでリセットする。
+    /// </summary>
+    internal static void OnSceneUnloaded()
+    {
+        int destroyed = 0;
+        foreach (var m in s_transplantedCache.Values)
+        {
+            if (m != null)
+            {
+                Object.Destroy(m);
+                destroyed++;
+            }
+        }
+        s_transplantedCache.Clear();
+        s_backups.Clear();
+        PatchLogger.LogInfo($"[SwimWearStockingPatch] シーンアンロード: transplanted mesh {destroyed} 件破棄、キャッシュクリア");
+    }
+
+    private static bool Prefix(CharacterHandle __instance, int __0)
+    {
+        if (__instance == null || __instance.Chara == null || __instance.m_lastLoadArg == null) return true;
+        if (__instance.m_lastLoadArg.Costume != CostumeType.SwimWear) return true;
+        if (KneeSocksLoader.IsPreloading) return true;
+
+        var charId = __instance.GetCharID();
+
+        // 水着×ストッキングは CostumeChanger の StockingOverrideStore 経由でのみ適用する。
+        // override が無いと vanilla の IsDisableStocking 相当（= ストッキング無し）。
+        // （m_lastLoadArg.Stocking に他コスチューム由来の値が残っていても無視する）
+        // override 未設定 or override=0（デフォルト／ストッキング無し）は本パッチでは何もせず
+        // 注入済みメッシュだけ掃除する。vanilla の IsDisableStocking 相当の挙動に委ねる。
+        bool hasOverride = StockingOverrideStore.TryGet(charId, out var overrideType)
+                           && overrideType != 0;
+        bool isKneeSocks = hasOverride && StockingOverrideStore.IsKneeSocksType(overrideType);
+
+        if (Plugin.ConfigDisableStockings.Value) { hasOverride = false; isKneeSocks = false; }
+
+        if (!hasOverride)
+        {
+            ClearStockingSync(__instance);
+            __instance.m_lastLoadArg.Stocking = 0;
+            return false;
+        }
+
+        if (!StockingsDonorLoader.IsReady)
+        {
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] donor 未 Ready（{charId}）、通常 async に委譲");
+            return true;
+        }
+
+        if (!StockingsDonorLoader.TryGetDonor(charId, out var donor))
+        {
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] donor 未キャッシュ: {charId}");
+            return true;
+        }
+
+        // KneeSocks 系は KneeSocksLoader のプリロードが必要
+        if (isKneeSocks && !KneeSocksLoader.IsLoaded)
+        {
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] KneeSocks 未ロード（{charId}）、通常 async に委譲");
+            return true;
+        }
+
+        if (!ApplyStockingSync(__instance, overrideType, donor, isKneeSocks))
+        {
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] ApplyStockingSync 失敗: {charId} override={overrideType} knee={isKneeSocks}");
+            return true;
+        }
+
+        // CostumeChangerPatch に合わせ、KneeSocks 系は m_lastLoadArg.Stocking=0 として記録
+        __instance.m_lastLoadArg.Stocking = isKneeSocks ? 0 : overrideType;
+        return false;
+    }
+
+    private static void ClearStockingSync(CharacterHandle handle)
+    {
+        var chara = handle.Chara;
+        if (chara == null) return;
+
+        int key = (int)handle.GetCharID();
+
+        // 注入 mesh_stockings を削除
+        var injected = chara.GetComponentsInChildren<SkinnedMeshRenderer>(true)
+            .FirstOrDefault(m => m.name == InjectedName);
+        if (injected != null)
+        {
+            Object.Destroy(injected.gameObject);
+            PatchLogger.LogInfo($"[SwimWearStockingPatch] 注入 mesh_stockings 削除: {handle.GetCharID()}");
+        }
+
+        // sharedMesh を元に戻す（SMR が破棄済みなら Unity == が true で skip される）
+        if (s_backups.TryGetValue(key, out var backup))
+        {
+            if (backup.LowerSmr != null && backup.LowerOriginalMesh != null)
+                backup.LowerSmr.sharedMesh = backup.LowerOriginalMesh;
+            if (backup.LowerFootSmr != null && backup.LowerFootOriginalMesh != null)
+                backup.LowerFootSmr.sharedMesh = backup.LowerFootOriginalMesh;
+            s_backups.Remove(key);
+            PatchLogger.LogInfo($"[SwimWearStockingPatch] sharedMesh 復元: {handle.GetCharID()}");
+        }
+    }
+
+    private static bool ApplyStockingSync(CharacterHandle handle, int overrideType, SkinnedMeshRenderer donor, bool isKneeSocks)
+    {
+        var chara = handle.Chara;
+        if (chara == null) return false;
+
+        var renderers = chara.GetComponentsInChildren<SkinnedMeshRenderer>(true);
+
+        // 目標メッシュ/ボーン/マテリアルを overrideType から決定
+        Mesh targetMesh;
+        Transform[] targetBonesSrc;
+        Transform targetRootBoneSrc;
+        Material targetMat;
+
+        if (isKneeSocks)
+        {
+            var kneeSocks = KneeSocksLoader.KneeSocksSmr;
+            if (kneeSocks == null || kneeSocks.sharedMesh == null)
+            {
+                PatchLogger.LogWarning("[SwimWearStockingPatch] KneeSocks SMR 未ロード");
+                return false;
+            }
+            targetMesh = kneeSocks.sharedMesh;
+            targetBonesSrc = kneeSocks.bones;
+            targetRootBoneSrc = kneeSocks.rootBone;
+            targetMat = KneeSocksLoader.GetMaterialForOverride(overrideType);
+        }
+        else
+        {
+            targetMesh = donor.sharedMesh;
+            targetBonesSrc = donor.bones;
+            targetRootBoneSrc = donor.rootBone;
+            targetMat = StockingsDonorLoader.GetMaterial(overrideType);
+        }
+
+        // 1. 注入 SMR を取得 or 生成（生成時は空の GO+SMR。mesh/bones は下で統一的に設定）
+        var existing = renderers.FirstOrDefault(m => m.name == InjectedName);
+        SkinnedMeshRenderer smr;
+        bool created = existing == null;
+        if (!created)
+        {
+            smr = existing;
+        }
+        else
+        {
+            smr = CreateInjected(chara);
+            if (smr == null) return false;
+        }
+
+        // 2. mesh + bones を常にセット（新規は初回、既存は type 変更時のみ差替え）
+        if (smr.sharedMesh != targetMesh)
+        {
+            smr.sharedMesh = targetMesh;
+            var boneDict = BuildBoneDict(chara);
+            RemapBonesInto(smr, targetBonesSrc, targetRootBoneSrc, boneDict, chara.transform);
+        }
+
+        if (targetMat != null) smr.sharedMaterial = targetMat;
+        else PatchLogger.LogWarning($"[SwimWearStockingPatch] material 未ロード: override={overrideType}");
+
+        smr.gameObject.SetActive(true);
+
+        ApplyBlendShapeTransplant(handle, chara, renderers, 100f, isKneeSocks);
+
+        PatchLogger.LogInfo($"[SwimWearStockingPatch] 適用: {handle.GetCharID()} override={overrideType} knee={isKneeSocks} created={created} meshVerts={targetMesh.vertexCount} bones={smr.bones?.Length ?? 0}");
+        return true;
+    }
+
+    private static void ApplyBlendShapeTransplant(CharacterHandle handle, GameObject chara, SkinnedMeshRenderer[] renderers, float shrinkWeight, bool isKneeSocks)
+    {
+        var charId = handle.GetCharID();
+        int key = (int)charId;
+
+        if (!StockingsDonorLoader.TryGetLowerDonor(charId, out var lowerDonor) || lowerDonor.sharedMesh == null)
+        {
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] lower donor 未キャッシュ: {charId}");
+            return;
+        }
+
+        var swimLower = renderers.FirstOrDefault(m => m.name == "mesh_skin_lower");
+        var swimLowerFoot = renderers.FirstOrDefault(m => m.name == "mesh_skin_lower_foot");
+
+        if (!s_backups.TryGetValue(key, out var backup))
+        {
+            backup = new SwimwearBackup();
+            s_backups[key] = backup;
+        }
+
+        TransplantInto(swimLower, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, ref backup.LowerSmr, ref backup.LowerOriginalMesh);
+        TransplantInto(swimLowerFoot, lowerDonor.sharedMesh, key, shrinkWeight, isKneeSocks, ref backup.LowerFootSmr, ref backup.LowerFootOriginalMesh);
+    }
+
+    private static void TransplantInto(SkinnedMeshRenderer target, Mesh donorMesh, int charKey, float shrinkWeight, bool isKneeSocks,
+        ref SkinnedMeshRenderer backupSmr, ref Mesh backupOriginal)
+    {
+        if (target == null || target.sharedMesh == null) return;
+
+        var cacheKey = (target.sharedMesh.GetInstanceID(), charKey, isKneeSocks);
+
+        if (!s_transplantedCache.TryGetValue(cacheKey, out var transplanted) || transplanted == null)
+        {
+            // 元メッシュが既に transplanted だった場合（reload で cache miss）はバックアップ済みと想定しスキップ
+            // ここでは target.sharedMesh が元の mesh（swim 生）であることを期待
+            transplanted = BuildTransplantedMesh(target.sharedMesh, donorMesh, isKneeSocks);
+            if (transplanted == null) return;
+            s_transplantedCache[cacheKey] = transplanted;
+        }
+
+        if (target.sharedMesh != transplanted)
+        {
+            if (backupSmr == null || backupOriginal == null)
+            {
+                backupSmr = target;
+                backupOriginal = target.sharedMesh;
+            }
+            target.sharedMesh = transplanted;
+        }
+
+        // weight 設定: isKneeSocks=true かつ Luna Casual ドナー取得済みなら skin_kneehigh=100 方式
+        // ドナー未取得（フォールバック）時は skin_kneehigh blendShape が移植されないので、
+        // 従来の skin_stocking=100 方式を維持して z-fighting 再発を防ぐ
+        bool useKneehighWeights = isKneeSocks && KneeSocksLoader.DonorSkinLower != null;
+        if (useKneehighWeights)
+        {
+            SetBlendShape(target, "blendShape_skin_lower.skin_stocking", 0f);
+            SetBlendShape(target, "blendShape_skin_lower.skin_socks", 0f);
+            SetBlendShape(target, "blendShape_skin_lower.skin_stocking_lower", 0f);
+            SetBlendShape(target, "blendShape_skin_lower.skin_kneehigh", 100f);
+        }
+        else
+        {
+            SetBlendShape(target, "blendShape_skin_lower.skin_stocking", shrinkWeight);
+            SetBlendShape(target, "blendShape_skin_lower.skin_socks", shrinkWeight);
+            SetBlendShape(target, "blendShape_skin_lower.skin_stocking_lower", shrinkWeight);
+            SetBlendShape(target, "blendShape_skin_lower.skin_kneehigh", 0f);
+        }
+    }
+
+    /// <summary>
+    /// targetMesh の頂点構造を保ったまま、blendShape delta を nearest-neighbor で転写した新 Mesh を生成する。
+    /// isKneeSocks=true の場合は Uniform donor（skin_stocking 系）に加えて
+    /// KneeSocksLoader の Luna Casual ドナー（skin_kneehigh）も移植する。
+    /// 移植ロジックは MeshBlendShapeTransplanter に委譲する。
+    /// </summary>
+    private static Mesh BuildTransplantedMesh(Mesh targetMesh, Mesh donorMesh, bool isKneeSocks)
+    {
+        if (!isKneeSocks)
+        {
+            // isKneeSocks=false: 既存どおり単一ドナー（Uniform）から skin_stocking 系のみ移植
+            return MeshBlendShapeTransplanter.Transplant(targetMesh, donorMesh, s_transplantShapeNames, "SwimWearStockingPatch");
+        }
+
+        // isKneeSocks=true: Uniform ドナー + Luna Casual ドナーの複数ドナー移植
+        var kneehighDonor = KneeSocksLoader.DonorSkinLower;
+        if (kneehighDonor == null)
+        {
+            // DonorSkinLower 未取得: フォールバックとして従来方式（skin_stocking=100）を維持
+            PatchLogger.LogWarning("[SwimWearStockingPatch] DonorSkinLower 未取得のためフォールバック (skin_stocking=100)");
+            return MeshBlendShapeTransplanter.Transplant(targetMesh, donorMesh, s_transplantShapeNames, "SwimWearStockingPatch");
+        }
+
+        // Uniform ドナー: skin_stocking 系 3 shape + Luna Casual ドナー: skin_kneehigh
+        var donors = new (Mesh donor, System.Collections.Generic.IReadOnlyList<string> shapeNames)[]
+        {
+            (donorMesh, s_transplantShapeNames),
+            (kneehighDonor, new[] { "blendShape_skin_lower.skin_kneehigh" }),
+        };
+        return MeshBlendShapeTransplanter.Transplant(targetMesh, donors, "SwimWearStockingPatch");
+    }
+
+    private static void SetBlendShape(SkinnedMeshRenderer smr, string name, float weight)
+    {
+        if (smr == null || smr.sharedMesh == null) return;
+        int idx = smr.sharedMesh.GetBlendShapeIndex(name);
+        if (idx >= 0) smr.SetBlendShapeWeight(idx, weight);
+    }
+
+    /// <summary>
+    /// 水着キャラ配下に空の "mesh_stockings" GO + SkinnedMeshRenderer を作る。
+    /// mesh/bones/material は呼び出し側が設定する。親は既存 mesh_skin_lower と揃える。
+    /// </summary>
+    private static SkinnedMeshRenderer CreateInjected(GameObject chara)
+    {
+        var referenceSmr = chara.GetComponentsInChildren<SkinnedMeshRenderer>(true)
+            .FirstOrDefault(m => m.name == "mesh_skin_lower");
+        var parentTransform = referenceSmr != null ? referenceSmr.transform.parent : chara.transform;
+
+        var go = new GameObject(InjectedName);
+        go.transform.SetParent(parentTransform, false);
+
+        return go.AddComponent<SkinnedMeshRenderer>();
+    }
+
+    /// <summary>
+    /// donor の bones[] を chara 階層の同名 Transform にリマップして target SMR に適用する。
+    /// </summary>
+    private static void RemapBonesInto(SkinnedMeshRenderer target, Transform[] donorBones, Transform donorRootBone,
+        Dictionary<string, Transform> boneDict, Transform fallback)
+    {
+        var src = donorBones ?? System.Array.Empty<Transform>();
+        var newBones = new Transform[src.Length];
+        int missing = 0;
+        for (int i = 0; i < src.Length; i++)
+        {
+            var db = src[i];
+            if (db != null && boneDict.TryGetValue(db.name, out var mapped))
+                newBones[i] = mapped;
+            else
+            {
+                missing++;
+                newBones[i] = fallback;
+            }
+        }
+        target.bones = newBones;
+
+        if (donorRootBone != null && boneDict.TryGetValue(donorRootBone.name, out var root))
+            target.rootBone = root;
+        else
+            target.rootBone = fallback;
+
+        if (missing > 0)
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] bone 未対応 {missing}/{src.Length}");
+    }
+
+    /// <summary>
+    /// キャラ配下の Transform を名前 → Transform の辞書にする。名前衝突時は先勝ち（最初に見つけた方を採用）し、
+    /// 衝突件数をまとめてログに出す（L_hand / R_hand は名前が違うので衝突しないが、LOD 複製やミラーノードで同名が出ると後勝ち上書きで誤マッピングする恐れがあるため）。
+    /// </summary>
+    private static Dictionary<string, Transform> BuildBoneDict(GameObject chara)
+    {
+        var dict = new Dictionary<string, Transform>(System.StringComparer.OrdinalIgnoreCase);
+        int collisions = 0;
+        foreach (var t in chara.GetComponentsInChildren<Transform>(true))
+        {
+            if (!dict.ContainsKey(t.name))
+                dict[t.name] = t;
+            else
+                collisions++;
+        }
+        if (collisions > 0)
+            PatchLogger.LogWarning($"[SwimWearStockingPatch] bone 名衝突 {collisions} 件を先勝ちで無視 (chara={chara.name})");
+        return dict;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
@@ -76,30 +76,22 @@ public static class SwimWearStockingPatch
     /// </summary>
     internal static void OnSceneUnloaded()
     {
-        int destroyed = 0;
-        foreach (var m in s_transplantedCache.Values)
-        {
-            if (m != null)
-            {
-                Object.Destroy(m);
-                destroyed++;
-            }
-        }
+        // Mesh オブジェクト自体は Destroy しない:
+        //   水着キャラ GameObject が DontDestroyOnLoad 等でシーンを跨いで生存するケースがあり、
+        //   その SMR が transplanted/resolved mesh を参照している。ここで Destroy すると
+        //   次シーンで SMR が fake-null mesh を抱えて肌が消える。
+        //   キャッシュ辞書だけクリアし、Mesh は SMR が手放した時点で Unity GC に回収させる。
+        int transplantedCount = s_transplantedCache.Count;
         s_transplantedCache.Clear();
 
-        int resolvedDestroyed = 0;
-        foreach (var pair in s_resolvedCache.Values)
-        {
-            if (pair.donor != null) { Object.Destroy(pair.donor); resolvedDestroyed++; }
-            if (pair.skin != null) { Object.Destroy(pair.skin); resolvedDestroyed++; }
-        }
+        int resolvedCount = s_resolvedCache.Count;
         s_resolvedCache.Clear();
         s_resolvedAppliedIds.Clear();
 
         // s_backups.LowerOriginalMesh / LowerFootOriginalMesh はゲーム本体所有の sharedMesh のため
         // Destroy せず参照のみクリアする（Destroy するとゲーム側のメッシュが消えて破綻する）。
         s_backups.Clear();
-        PatchLogger.LogInfo($"[SwimWearStockingPatch] シーンアンロード: transplanted {destroyed} 件、resolved {resolvedDestroyed} 件破棄");
+        PatchLogger.LogInfo($"[SwimWearStockingPatch] シーンアンロード: cache クリア (transplanted {transplantedCount} 件、resolved {resolvedCount} 件)");
     }
 
     /// <summary>

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
@@ -106,6 +106,11 @@ public class CostumePickerController : MonoBehaviour
         m_view.OnBackClicked += HandleBackClicked;
         m_view.OnResetAllClicked += HandleResetAllClicked;
         m_view.OnUnlockAllClicked += HandleUnlockAllClicked;
+        m_view.OnStockingOffsetChanged += HandleStockingOffsetChanged;
+        m_view.OnStockingSkinShrinkChanged += HandleStockingSkinShrinkChanged;
+        m_view.OnStockingFalloffChanged += HandleStockingFalloffChanged;
+        m_view.OnStockingShapeFalloffChanged += HandleStockingShapeFalloffChanged;
+        m_view.OnTuneResetClicked += HandleTuneResetClicked;
     }
 
     private void OnDestroy()
@@ -120,6 +125,11 @@ public class CostumePickerController : MonoBehaviour
             m_view.OnBackClicked -= HandleBackClicked;
             m_view.OnResetAllClicked -= HandleResetAllClicked;
             m_view.OnUnlockAllClicked -= HandleUnlockAllClicked;
+            m_view.OnStockingOffsetChanged -= HandleStockingOffsetChanged;
+            m_view.OnStockingSkinShrinkChanged -= HandleStockingSkinShrinkChanged;
+            m_view.OnStockingFalloffChanged -= HandleStockingFalloffChanged;
+            m_view.OnStockingShapeFalloffChanged -= HandleStockingShapeFalloffChanged;
+            m_view.OnTuneResetClicked -= HandleTuneResetClicked;
         }
         if (Instance == this) Instance = null;
     }
@@ -1113,7 +1123,95 @@ public class CostumePickerController : MonoBehaviour
             UnlockAllEnabled = IsEndingClearedFor(m_activeChar),
             VisibleCasts = m_visibleCasts.AsReadOnly(),
             VisibleCastSelectedIndex = m_visibleCasts.IndexOf(m_activeChar),
+            StockingOffset = Plugin.ConfigStockingOffset?.Value ?? 0f,
+            StockingSkinShrink = Plugin.ConfigStockingSkinShrink?.Value ?? 0f,
+            StockingFalloffRadius = Plugin.ConfigStockingSkinFalloffRadius?.Value ?? 0f,
+            StockingShapeFalloffRadius = Plugin.ConfigStockingShapeFalloffRadius?.Value ?? 0f,
+            StockingOffsetMax = 0.01f,
+            StockingSkinShrinkMax = 0.01f,
+            StockingFalloffRadiusMax = 0.01f,
+            StockingShapeFalloffRadiusMax = 0.01f,
         };
+    }
+
+    private void HandleStockingOffsetChanged(float meters)
+    {
+        if (Plugin.ConfigStockingOffset == null) return;
+        Plugin.ConfigStockingOffset.Value = Mathf.Clamp(meters, 0f, 0.01f);
+        ReapplyStockingForTune();
+    }
+
+    private void HandleStockingSkinShrinkChanged(float meters)
+    {
+        if (Plugin.ConfigStockingSkinShrink == null) return;
+        Plugin.ConfigStockingSkinShrink.Value = Mathf.Clamp(meters, 0f, 0.01f);
+        ReapplyStockingForTune();
+    }
+
+    private void HandleStockingFalloffChanged(float meters)
+    {
+        if (Plugin.ConfigStockingSkinFalloffRadius == null) return;
+        Plugin.ConfigStockingSkinFalloffRadius.Value = Mathf.Clamp(meters, 0f, 0.01f);
+        ReapplyStockingForTune();
+    }
+
+    private void HandleStockingShapeFalloffChanged(float meters)
+    {
+        if (Plugin.ConfigStockingShapeFalloffRadius == null) return;
+        Plugin.ConfigStockingShapeFalloffRadius.Value = Mathf.Clamp(meters, 0f, 0.01f);
+        ReapplyStockingForTune();
+    }
+
+    /// <summary>
+    /// パンスト微調整 4 項目（Offset / SkinShrink / FalloffRadius / ShapeFalloff）を
+    /// ConfigEntry の DefaultValue にまとめて戻し、UI と適用結果を更新する。
+    /// </summary>
+    private void HandleTuneResetClicked()
+    {
+        ResetConfigToDefault(Plugin.ConfigStockingOffset);
+        ResetConfigToDefault(Plugin.ConfigStockingSkinShrink);
+        ResetConfigToDefault(Plugin.ConfigStockingSkinFalloffRadius);
+        ResetConfigToDefault(Plugin.ConfigStockingShapeFalloffRadius);
+        ReapplyStockingForTune();
+
+        // スライダーの表示も更新する（プログラム側で値を変えただけだとスライダーは追従しない）。
+        // 設定画面の slider 群は RenderSettings 経由で更新する（Render は picker タブ用）。
+        if (m_view != null) m_view.RenderSettings(BuildSettingsData());
+    }
+
+    private static void ResetConfigToDefault(BepInEx.Configuration.ConfigEntry<float> entry)
+    {
+        if (entry == null) return;
+        if (entry.DefaultValue is float def) { entry.Value = def; return; }
+        // DefaultValue が float でないと無音でリセット失敗 → ユーザーから不可視の崩れになるので Warning。
+        PatchLogger.LogWarning(
+            $"[CostumePickerController] Config '{entry.Definition?.Key}' の DefaultValue が float ではありません: " +
+            $"{entry.DefaultValue?.GetType().FullName ?? "null"}。リセットをスキップしました。");
+    }
+
+    /// <summary>
+    /// 微調整スライダー値変更後のライブ再適用。
+    /// 水着で stocking override が掛かっているキャラに対し、SwimWearStockingPatch の
+    /// 食い込み解消を新パラメータで再構築する。非水着・override 無し・KneeSocks の場合は no-op。
+    /// </summary>
+    private void ReapplyStockingForTune()
+    {
+        if (m_activeChar >= CharID.NUM) return;
+        if (!StockingOverrideStore.TryGet(m_activeChar, out var stk)) return;
+        if (StockingOverrideStore.IsKneeSocksType(stk)) return;
+        var env = GBSystem.Instance?.GetActiveEnvScene();
+        if (env == null) return;
+        if (!IsSwimWear(env, m_activeChar)) return;
+
+        SwimWearStockingPatch.InvalidateForReapply(m_activeChar);
+        try
+        {
+            env.ApplyStockings(m_activeChar, 0); // SwimWearStockingPatch は override store を見るので type 引数は無視
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[CostumePicker] tune 再適用失敗: {ex}");
+        }
     }
 
     /// <summary>

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
@@ -2,6 +2,7 @@ using BunnyGarden2FixMod.Utils;
 using Cysharp.Threading.Tasks;
 using GB;
 using GB.Game;
+using GB.Scene;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -749,7 +750,23 @@ public class CostumePickerController : MonoBehaviour
         var env = GBSystem.Instance?.GetActiveEnvScene();
         if (env != null)
         {
-            if (StockingOverrideStore.IsKneeSocksType(type))
+            bool isSwim = IsSwimWear(env, m_activeChar);
+
+            if (isSwim)
+            {
+                // 水着は SwimWearStockingPatch が override store を source of truth として
+                // 全タイプ（0=解除 / 1–4=パンスト / 5–7=ニーソックス）を同期処理する。
+                // type 引数は SwimWearStockingPatch 側で無視されるので 0 を渡す。
+                try
+                {
+                    env.ApplyStockings(m_activeChar, 0);
+                }
+                catch (Exception ex)
+                {
+                    PatchLogger.LogWarning($"[CostumePicker] 水着ストッキング切替失敗: {ex}");
+                }
+            }
+            else if (StockingOverrideStore.IsKneeSocksType(type))
             {
                 // ニーソックス系: 直接メッシュ差し替え（env.ApplyStockings は type 0–4 専用）
                 var charObj = env.FindCharacter(m_activeChar);
@@ -779,6 +796,17 @@ public class CostumePickerController : MonoBehaviour
             }
         }
         m_view.Render(BuildRenderData());
+    }
+
+    /// <summary>
+    /// 現在シーン内の <paramref name="id"/> の CharacterHandle から Costume を取得し、
+    /// SwimWear かどうかを判定する。まだロードされていない／見つからない場合は false。
+    /// </summary>
+    private static bool IsSwimWear(EnvSceneBase env, CharID id)
+    {
+        if (env == null || env.m_characters == null) return false;
+        var handle = env.m_characters.Find(x => x != null && x.GetCharID() == id);
+        return handle?.m_lastLoadArg?.Costume == CostumeType.SwimWear;
     }
 
     private void ResetAllTabs()

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerView.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerView.cs
@@ -55,6 +55,18 @@ public class CostumePickerView : MonoBehaviour
 
         /// <summary>VisibleCasts の中で現在ピッカーが対象としているキャストのインデックス。</summary>
         public int VisibleCastSelectedIndex;
+
+        // パンスト微調整 (m 単位)
+        public float StockingOffset;
+        public float StockingSkinShrink;
+        public float StockingFalloffRadius;
+        public float StockingShapeFalloffRadius;
+
+        // 各スライダーの最大値 (m 単位、Config.AcceptableValueRange と一致)
+        public float StockingOffsetMax;
+        public float StockingSkinShrinkMax;
+        public float StockingFalloffRadiusMax;
+        public float StockingShapeFalloffRadiusMax;
     }
 
     public event Action<int> OnTabClicked;
@@ -72,6 +84,15 @@ public class CostumePickerView : MonoBehaviour
     public event Action OnResetAllClicked;
 
     public event Action OnUnlockAllClicked;
+
+    /// <summary>パンスト微調整スライダーの値変更 (引数は m 単位)。</summary>
+    public event Action<float> OnStockingOffsetChanged;
+
+    public event Action<float> OnStockingSkinShrinkChanged;
+
+    public event Action<float> OnStockingFalloffChanged;
+    public event Action<float> OnStockingShapeFalloffChanged;
+    public event Action OnTuneResetClicked;
 
     private UIDocument m_doc;
     private PanelSettings m_settings;
@@ -93,6 +114,13 @@ public class CostumePickerView : MonoBehaviour
     private Button m_resetAllButton;          // W/S キー選択ハイライトのため保持
     private Button m_unlockAllButton;         // enable/disable 切替のため保持
     private Label m_unlockAllNote;            // 常時表示の説明ラベル（将来ラベル差替え予定なら必要）
+
+    // パンスト微調整スライダー（設定画面下部）
+    private UITSlider m_offsetSlider;
+    private UITSlider m_skinShrinkSlider;
+    private UITSlider m_falloffSlider;
+    private UITSlider m_shapeFalloffSlider;
+    private Button m_tuneResetButton;
 
     private enum ViewMode
     { Picker, Settings }
@@ -146,7 +174,20 @@ public class CostumePickerView : MonoBehaviour
             m_unlockAllButton.SetEnabled(data.UnlockAllEnabled);
             m_unlockAllButton.style.opacity = data.UnlockAllEnabled ? 1f : 0.4f;
         }
+        UpdateSlider(m_offsetSlider, data.StockingOffset, data.StockingOffsetMax);
+        UpdateSlider(m_skinShrinkSlider, data.StockingSkinShrink, data.StockingSkinShrinkMax);
+        UpdateSlider(m_falloffSlider, data.StockingFalloffRadius, data.StockingFalloffRadiusMax);
+        UpdateSlider(m_shapeFalloffSlider, data.StockingShapeFalloffRadius, data.StockingShapeFalloffRadiusMax);
     }
+
+    private static void UpdateSlider(UITSlider s, float current, float max)
+    {
+        if (s == null) return;
+        if (max > 0f) s.SetRange(0f, max);
+        s.SetValue(current);
+    }
+
+    private static string FormatMm(float meters) => $"{meters * 1000f:F1}mm";
 
     /// <summary>
     /// 設定画面 2 ボタンのキー操作選択ハイライトを更新する。0=Reset, 1=UnlockAll。
@@ -381,6 +422,47 @@ public class CostumePickerView : MonoBehaviour
             9, UITTheme.Text.Secondary, m_font, TextAnchor.UpperLeft);
         m_unlockAllNote.style.whiteSpace = WhiteSpace.Normal;
         m_settingsContent.Add(m_unlockAllNote);
+
+        // ─── 水着のパンスト微調整セクション ───
+        var tuneHeading = UITFactory.CreateLabel(
+            "水着のパンスト微調整",
+            11, UITTheme.Text.Accent, m_font, TextAnchor.MiddleLeft);
+        tuneHeading.style.marginTop = 16;
+        tuneHeading.style.marginBottom = 4;
+        m_settingsContent.Add(tuneHeading);
+
+        m_offsetSlider = AddTuneSlider("パンスト押し出し", 0.01f, v => OnStockingOffsetChanged?.Invoke(v));
+        m_skinShrinkSlider = AddTuneSlider("肌押し込み", 0.01f, v => OnStockingSkinShrinkChanged?.Invoke(v));
+        m_falloffSlider = AddTuneSlider("境界フェード", 0.01f, v => OnStockingFalloffChanged?.Invoke(v));
+        // 肌縮みフェードは blendShape 全 frame の再構築を伴って重いので、ドラッグ完了時のみ反映する。
+        m_shapeFalloffSlider = AddTuneSlider("肌縮みフェード", 0.01f, v => OnStockingShapeFalloffChanged?.Invoke(v), commitOnly: true);
+
+        var tuneNote = UITFactory.CreateLabel(
+            "※ パンスト押し出し: 水着の食い込みは出るが水着を貫通\n" +
+            "※ 肌押し込み: 貫通はしないが水着の食い込みは出ない",
+            9, UITTheme.Text.Secondary, m_font, TextAnchor.UpperLeft);
+        tuneNote.style.whiteSpace = WhiteSpace.Normal;
+        tuneNote.style.marginTop = 4;
+        m_settingsContent.Add(tuneNote);
+
+        m_tuneResetButton = UITFactory.CreateButton(
+            "パンスト設定をリセット",
+            () => OnTuneResetClicked?.Invoke(),
+            11, m_font);
+        m_tuneResetButton.style.marginTop = 8;
+        m_tuneResetButton.style.paddingTop = 4;
+        m_tuneResetButton.style.paddingBottom = 4;
+        m_settingsContent.Add(m_tuneResetButton);
+    }
+
+    private UITSlider AddTuneSlider(string label, float maxMeters, Action<float> onChanged, bool commitOnly = false)
+    {
+        var s = new UITSlider();
+        s.Setup(label, 0f, maxMeters, m_font, FormatMm);
+        if (commitOnly) s.OnValueCommitted += onChanged;
+        else s.OnValueChanged += onChanged;
+        m_settingsContent.Add(s);
+        return s;
     }
 
     private void BuildHeaderButtons()

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -104,6 +104,10 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigHideButtonGuide;
     public static ConfigEntry<bool> ConfigHideLikabilityGauge;
     public static ConfigEntry<bool> ConfigSwimWearStocking;
+    public static ConfigEntry<float> ConfigStockingOffset;
+    public static ConfigEntry<float> ConfigStockingSkinShrink;
+    public static ConfigEntry<float> ConfigStockingSkinFalloffRadius;
+    public static ConfigEntry<float> ConfigStockingShapeFalloffRadius;
 
     private GameObject freeCamObject;
     private Camera freeCam;
@@ -415,6 +419,49 @@ public class Plugin : BaseUnityPlugin
             false,
             "true にすると水着コスチューム着用中にストッキングを適用できるようになります。\n" +
             "水着モデルには本来ストッキング用ブレンドシェイプがないため、同キャラの Uniform コスチュームからデータを移植します。");
+
+        ConfigStockingOffset = Config.Bind(
+            "CostumeChanger",
+            "StockingOffset",
+            0f,
+            new BepInEx.Configuration.ConfigDescription(
+                "水着+ストッキング適用時、stocking 頂点を肌より外側へ保つ最小距離（メートル）。\n" +
+                "押し出すと水着の食い込み（タイトな演出）が再現できるが、stocking が水着を貫通する。\n" +
+                "0 で無効化。デフォルト 0 (無効)。",
+                new BepInEx.Configuration.AcceptableValueRange<float>(0f, 0.01f)));
+
+        ConfigStockingSkinShrink = Config.Bind(
+            "CostumeChanger",
+            "StockingSkinShrink",
+            0.001f,
+            new BepInEx.Configuration.ConfigDescription(
+                "水着+ストッキング適用時、肌（mesh_skin_lower）の頂点を「stocking 押し出し後表面より内側」に\n" +
+                "保つ目標距離（メートル）。stocking と肌が z-fighting している箇所では、まず肌を\n" +
+                "stocking 表面まで引っ込めてから、さらにこの距離だけ内側に押し込む。\n" +
+                "押し込むと、肌の貫通はなくなるが、水着の食い込み（タイトな演出）が再現できない。\n" +
+                "0 で無効化。デフォルト 0.001 (1mm)。",
+                new BepInEx.Configuration.AcceptableValueRange<float>(0f, 0.01f)));
+
+        ConfigStockingSkinFalloffRadius = Config.Bind(
+            "CostumeChanger",
+            "StockingSkinFalloffRadius",
+            0.001f,
+            new BepInEx.Configuration.ConfigDescription(
+                "肌の押し込み量を、隣接 mesh（mesh_skin_upper 等）からの距離で線形フェードさせる半径（メートル）。\n" +
+                "距離 0 で押し込み 0、半径以上で 100%。境界での段差を防ぐ。0 で無効化（一様押し込み）。\n" +
+                "デフォルト 0.001 (1mm)。",
+                new BepInEx.Configuration.AcceptableValueRange<float>(0f, 0.01f)));
+
+        ConfigStockingShapeFalloffRadius = Config.Bind(
+            "CostumeChanger",
+            "StockingShapeFalloffRadius",
+            0.001f,
+            new BepInEx.Configuration.ConfigDescription(
+                "skin_stocking 系 blendShape (skin_stocking / skin_socks / skin_stocking_lower) の delta 自体を、\n" +
+                "隣接 mesh（mesh_skin_upper 等）からの距離で線形フェードさせる半径（メートル）。\n" +
+                "距離 0 で blendShape 効果 0、半径以上で 100%。境界（ウエスト等）の段差を解消する。\n" +
+                "0 で無効化（blendShape 効果は全頂点 100%）。デフォルト 0.001 (1mm)。",
+                new BepInEx.Configuration.AcceptableValueRange<float>(0f, 0.01f)));
 
         Logger = base.Logger;
         PatchLogger.Initialize(Logger);

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -103,6 +103,7 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigHideMoneyInSpecialScenes;
     public static ConfigEntry<bool> ConfigHideButtonGuide;
     public static ConfigEntry<bool> ConfigHideLikabilityGauge;
+    public static ConfigEntry<bool> ConfigSwimWearStocking;
 
     private GameObject freeCamObject;
     private Camera freeCam;
@@ -408,6 +409,13 @@ public class Plugin : BaseUnityPlugin
             false,
             "true にするとラブカウンター（好感度ゲージ）を常時非表示にします。F9パネルまたはこのコンフィグでON/OFFできます。");
 
+        ConfigSwimWearStocking = Config.Bind(
+            "CostumeChanger",
+            "SwimWearStocking",
+            false,
+            "true にすると水着コスチューム着用中にストッキングを適用できるようになります。\n" +
+            "水着モデルには本来ストッキング用ブレンドシェイプがないため、同キャラの Uniform コスチュームからデータを移植します。");
+
         Logger = base.Logger;
         PatchLogger.Initialize(Logger);
 
@@ -426,6 +434,7 @@ public class Plugin : BaseUnityPlugin
         Patches.CastOrderUI.CastOrderController.Initialize(gameObject);
         Patches.CostumeChanger.CostumeChangerPatch.Initialize(gameObject);
         Patches.HideMoneyUI.HideMoneyUIController.Initialize(gameObject);
+        Patches.CostumeChanger.StockingsDonorLoader.Initialize(gameObject);
         PatchLogger.LogInfo($"プラグイン起動: {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION}");
         PatchLogger.LogInfo($"解像度パッチを適用しました: {Plugin.ConfigWidth.Value}x{Plugin.ConfigHeight.Value}");
         PatchLogger.LogInfo($"アンチエイリアシング設定: {Plugin.ConfigAntiAliasing.Value}");

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -416,7 +416,7 @@ public class Plugin : BaseUnityPlugin
         ConfigSwimWearStocking = Config.Bind(
             "CostumeChanger",
             "SwimWearStocking",
-            false,
+            true,
             "true にすると水着コスチューム着用中にストッキングを適用できるようになります。\n" +
             "水着モデルには本来ストッキング用ブレンドシェイプがないため、同キャラの Uniform コスチュームからデータを移植します。");
 

--- a/BunnyGarden2FixMod/UITKit/Components/UITSlider.cs
+++ b/BunnyGarden2FixMod/UITKit/Components/UITSlider.cs
@@ -1,0 +1,206 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace UITKit.Components;
+
+/// <summary>
+/// ラベル + 値表示 + 横スライダーを 1 つに束ねたコンポーネント。
+/// 上段にラベル(左)/現在値(右)、下段にスライダー本体を並べる縦構成。
+///
+/// 使い方:
+///   var s = new UITSlider();
+///   s.Setup("押し出し", 0f, 0.01f, font, v =&gt; $"{v * 1000f:F1}mm");
+///   s.OnValueChanged += v =&gt; ...
+///   parent.Add(s);
+///   s.SetValue(0.0005f); // event を発火させずに値を反映
+/// </summary>
+public class UITSlider : VisualElement
+{
+    /// <summary>値が変わるたびに発火（ドラッグ中も連続発火）。軽量な追従用。</summary>
+    public event Action<float> OnValueChanged;
+
+    /// <summary>値の操作が確定したタイミングで発火（ドラッグ終了 / クリック離し）。
+    /// 反映が重い処理（メッシュ再構築など）はこちらに繋ぐ。
+    /// プログラムからの SetValue / SetRange では発火しない。</summary>
+    public event Action<float> OnValueCommitted;
+
+    private Label m_nameLabel;
+    private Label m_valueLabel;
+    private Slider m_slider;
+    private Func<float, string> m_format;
+    private bool m_suppressEvents;
+    private float m_lastCommittedValue;
+
+    public float Value => m_slider != null ? m_slider.value : 0f;
+
+    public void Setup(string label, float min, float max, Font font = null, Func<float, string> formatter = null)
+    {
+        Clear();
+        m_format = formatter ?? (v => v.ToString("F2"));
+
+        style.flexDirection = FlexDirection.Column;
+        style.marginTop = 4;
+
+        var row = UITFactory.CreateRow();
+        row.style.alignItems = Align.Center;
+        Add(row);
+
+        m_nameLabel = UITFactory.CreateLabel(label, 10, UITTheme.Text.Primary, font, TextAnchor.MiddleLeft);
+        m_nameLabel.style.flexShrink = 0;
+        m_nameLabel.style.flexGrow = 1;
+        row.Add(m_nameLabel);
+
+        m_valueLabel = UITFactory.CreateLabel(m_format(min), 10, UITTheme.Text.Secondary, font, TextAnchor.MiddleRight);
+        m_valueLabel.style.flexShrink = 0;
+        row.Add(m_valueLabel);
+
+        m_slider = new Slider(min, max)
+        {
+            value = min,
+            showInputField = false,
+        };
+        m_slider.style.marginTop = 0;
+        m_slider.style.marginBottom = 0;
+        // 借用 theme stylesheet が Slider USS を含まない場合に track/dragger が高さ 0 で
+        // 描画されないことがあるので、コンテナとトラッカーに明示寸法を入れる。
+        m_slider.style.height = 18;
+        m_slider.style.minHeight = 18;
+        m_slider.RegisterCallback<GeometryChangedEvent>(_ =>
+        {
+            StyleSliderInternals(m_slider);
+            UpdateFillWidth();
+        });
+        m_slider.RegisterValueChangedCallback(evt =>
+        {
+            if (m_valueLabel != null) m_valueLabel.text = m_format(evt.newValue);
+            UpdateFillWidth();
+            if (m_suppressEvents) return;
+            OnValueChanged?.Invoke(evt.newValue);
+        });
+        // ドラッグ終了 / クリック離しで commit イベントを発火する。
+        // PointerUpEvent は dragger / track どちらでもバブルアップで届く。
+        // TrickleDown.TrickleDown を使うと dragger に capture される前に取れて取りこぼしを防げる。
+        m_slider.RegisterCallback<PointerUpEvent>(_ => CommitIfChanged(), TrickleDown.TrickleDown);
+        m_lastCommittedValue = m_slider.value;
+        Add(m_slider);
+    }
+
+    private void CommitIfChanged()
+    {
+        if (m_slider == null) return;
+        if (m_suppressEvents) return;
+        if (Mathf.Approximately(m_slider.value, m_lastCommittedValue)) return;
+        m_lastCommittedValue = m_slider.value;
+        OnValueCommitted?.Invoke(m_slider.value);
+    }
+
+    /// <summary>tracker 内の active-fill 要素の幅を 0..value..max の比率で更新する。</summary>
+    private void UpdateFillWidth()
+    {
+        if (m_slider == null) return;
+        var tracker = m_slider.Q(className: "unity-base-slider__tracker");
+        if (tracker == null) return;
+        var fill = tracker.Q("active-fill");
+        if (fill == null) return;
+        float range = m_slider.highValue - m_slider.lowValue;
+        if (range <= 0f) { fill.style.width = 0; return; }
+        float pct = Mathf.Clamp01((m_slider.value - m_slider.lowValue) / range);
+        fill.style.width = new Length(pct * 100f, LengthUnit.Percent);
+    }
+
+    /// <summary>イベント発火させずに値を反映する（Render 等で外部状態を流し込む用）。</summary>
+    public void SetValue(float v)
+    {
+        if (m_slider == null) return;
+        m_suppressEvents = true;
+        try
+        {
+            m_slider.value = Mathf.Clamp(v, m_slider.lowValue, m_slider.highValue);
+            if (m_valueLabel != null) m_valueLabel.text = m_format(m_slider.value);
+            m_lastCommittedValue = m_slider.value;
+        }
+        finally { m_suppressEvents = false; }
+    }
+
+    /// <summary>highValue を変更する。現在値が範囲外になれば clamp する。</summary>
+    public void SetRange(float min, float max)
+    {
+        if (m_slider == null) return;
+        m_suppressEvents = true;
+        try
+        {
+            m_slider.lowValue = min;
+            m_slider.highValue = max;
+            m_slider.value = Mathf.Clamp(m_slider.value, min, max);
+            if (m_valueLabel != null) m_valueLabel.text = m_format(m_slider.value);
+            m_lastCommittedValue = m_slider.value;
+        }
+        finally { m_suppressEvents = false; }
+    }
+
+    public void SetLabel(string text)
+    {
+        if (m_nameLabel != null) m_nameLabel.text = text;
+    }
+
+    /// <summary>
+    /// テーマ USS に依存せずトラック/ドラッガーが見えるよう、UnityEngine.UIElements.Slider 内部の
+    /// dragger-border/tracker/dragger 要素に最小限の塗り・寸法を入れる。
+    /// 名前は Unity 公式 USS の class 名 (.unity-base-slider__tracker など) と一致。
+    /// </summary>
+    private static void StyleSliderInternals(Slider slider)
+    {
+        // 想定 slider height = 18, tracker height = 4 → tracker.top = 7 で中央
+        const float kSliderHeight = 18f;
+        const float kTrackerHeight = 4f;
+        const float kTrackerTop = (kSliderHeight - kTrackerHeight) / 2f;
+        const float kDraggerSize = 12f;
+        const float kDraggerTop = (kSliderHeight - kDraggerSize) / 2f;
+
+        var tracker = slider.Q(className: "unity-base-slider__tracker");
+        if (tracker != null)
+        {
+            tracker.style.height = kTrackerHeight;
+            tracker.style.top = kTrackerTop;
+            tracker.style.backgroundColor = UITTheme.Tab.InactiveFill;
+            tracker.style.borderTopLeftRadius = 2;
+            tracker.style.borderTopRightRadius = 2;
+            tracker.style.borderBottomLeftRadius = 2;
+            tracker.style.borderBottomRightRadius = 2;
+            tracker.style.overflow = Overflow.Hidden; // fill が角丸内に収まるように
+
+            // アクティブ部分（左端〜dragger の間）の塗り。tracker 内に絶対配置で重ねる。
+            var fill = tracker.Q("active-fill");
+            if (fill == null)
+            {
+                fill = new VisualElement { name = "active-fill" };
+                fill.pickingMode = PickingMode.Ignore;
+                fill.style.position = Position.Absolute;
+                fill.style.left = 0;
+                fill.style.top = 0;
+                fill.style.bottom = 0;
+                tracker.Add(fill);
+            }
+            fill.style.backgroundColor = UITTheme.Tab.ActiveFill;
+        }
+        var dragger = slider.Q(className: "unity-base-slider__dragger");
+        if (dragger != null)
+        {
+            dragger.style.width = kDraggerSize;
+            dragger.style.height = kDraggerSize;
+            dragger.style.marginTop = 0;
+            dragger.style.top = kDraggerTop;
+            dragger.style.backgroundColor = UITTheme.Tab.ActiveFill;
+            dragger.style.borderTopLeftRadius = kDraggerSize / 2f;
+            dragger.style.borderTopRightRadius = kDraggerSize / 2f;
+            dragger.style.borderBottomLeftRadius = kDraggerSize / 2f;
+            dragger.style.borderBottomRightRadius = kDraggerSize / 2f;
+        }
+        var draggerBorder = slider.Q(className: "unity-base-slider__dragger-border");
+        if (draggerBorder != null)
+        {
+            draggerBorder.style.display = DisplayStyle.None;
+        }
+    }
+}

--- a/BunnyGarden2FixMod/UITKit/Components/UITSlider.cs
+++ b/BunnyGarden2FixMod/UITKit/Components/UITSlider.cs
@@ -156,7 +156,6 @@ public class UITSlider : VisualElement
         const float kTrackerHeight = 4f;
         const float kTrackerTop = (kSliderHeight - kTrackerHeight) / 2f;
         const float kDraggerSize = 12f;
-        const float kDraggerTop = (kSliderHeight - kDraggerSize) / 2f;
 
         var tracker = slider.Q(className: "unity-base-slider__tracker");
         if (tracker != null)
@@ -189,8 +188,11 @@ public class UITSlider : VisualElement
         {
             dragger.style.width = kDraggerSize;
             dragger.style.height = kDraggerSize;
-            dragger.style.marginTop = 0;
-            dragger.style.top = kDraggerTop;
+            // Unity 既定 USS は top: 50% + margin-top: -draggerHeight/2 で縦中央寄せする想定だが、
+            // テーマ USS が借用元と異なると margin-top が dragger サイズと一致せず下寄りになる。
+            // 自前のサイズ (kDraggerSize) で margin-top を再計算してセンター合わせを保証する。
+            dragger.style.top = new Length(50f, LengthUnit.Percent);
+            dragger.style.marginTop = -kDraggerSize / 2f;
             dragger.style.backgroundColor = UITTheme.Tab.ActiveFill;
             dragger.style.borderTopLeftRadius = kDraggerSize / 2f;
             dragger.style.borderTopRightRadius = kDraggerSize / 2f;


### PR DESCRIPTION
## 概要

水着コスチュームにパンスト/ニーハイを合成適用する機能と、ゲーム内 UI から食い込み/貫通量をライブ調整できる微調整スライダーを追加する。

スコープ:
- 水着への stocking/kneehigh 適用 (+ 同キャラ Uniform からの blendShape 移植)
- 食い込み解消の 2 パス K-NN penetration resolver
- 微調整 UI (CostumePicker 内に 4 スライダー + リセット)
- transplanter の SpatialGridIndex 高速化
- title-back 後の NRE と肌消失修正

## 主な変更点

### 新機能

- **水着への stocking/kneehigh 合成** (`SwimWearStockingPatch`, `KneeSocksLoader`, `StockingsDonorLoader`)
  - 水着コスチュームに同キャラ Uniform 衣装の `mesh_stockings` をボーン再マッピング付きで注入
  - `blendShape_skin_lower.skin_stocking` 系を nearest-neighbor で水着 lower mesh に移植
  - ニーソックス装着時は `skin_kneehigh` 方式で z-fighting を回避
- **2 パス mesh penetration resolver** (`MeshPenetrationResolver.cs`)
  - Pass 1: stocking を skin 表面まで揃えて設定値分外側へ push
  - Pass 2: skin を stocking 押し出し後表面まで戻して設定値分内側へ push
  - K-NN (K=3) 逆距離² 重み付け補間 + 法線誤近傍 invertGuard
- **per-vertex blendShape フェード** (`BlendShapeFalloffApplier.cs`)
  - `skin_stocking` 系 delta を隣接 mesh 距離でスケールし水着境界の段差を抑制
- **ゲーム内微調整 UI** (`CostumePickerView/Controller`, `UITSlider`)
  - 押し出し / 肌押し込み / 境界フェード / 肌縮みフェード (max 10mm) + リセットボタン
  - 重い処理 (肌縮みフェード) はドラッグ完了時のみ反映
- **SpatialGridIndex** (`SpatialGridIndex.cs`) — nearest-neighbor を O(N+M) 化

### バグ修正

- ニーハイ→パンスト切替時、`TransplantInto` 冒頭で vanilla mesh に復元して cache key と base mesh の不整合を防止
- title-back 後の NRE 連鎖 (lower.sharedMesh が一時的に null になる async preload 経路) をガード
- title-back 後の肌消失: 水着キャラ GameObject が DontDestroyOnLoad でシーン跨ぎ生存するケースで、OnSceneUnloaded の `Object.Destroy(transplanted)` が SMR を fake-null mesh に追い込んでいた → Mesh の Destroy をやめて辞書クリアのみに

## 技術的な補足

- 水着 lower mesh には `skin_stocking` 系 blendShape が存在しないため、Uniform donor から nearest-neighbor で delta を移植する（`MeshBlendShapeTransplanter`）。同キャラの Uniform を使うので頂点配置は近く、品質劣化は実用上見えない
- penetration resolver の cache key は量子化パラメータ込み (0.1mm 精度) で構成し、UI スライダーから値が変わるたびに cache miss して再計算する
- スライダーは USS 借用テーマで dragger が下寄りに見える問題があるため、Unity 既定の \`top:50% + margin-top:-half\` 方式を自前サイズで再計算してセンター合わせを保証

## レビューのポイント

- \`MeshPenetrationResolver.cs\` の 2 パス押し出しロジック（特に \`signedD\` の符号と \`invertGuard\`）
- \`SwimWearStockingPatch.OnSceneUnloaded\` の Mesh ライフタイム方針（Destroy しない理由）
- \`KneeSocksLoader.Apply\` の \`lower.sharedMesh\` null ガード（title-back の async race を吸収）

## 分かりづらい箇所の解説

- \`SpatialGridIndex.FindKNearest\` は逆距離² 重みの補間用に最近傍 K 個を返す。\`MeshPenetrationResolver\` のみが使用
- penetration resolver の \`adjSkin.vertices\` は \`referenceMesh.vertices\` を再取得して base から作る (\`skin_stocking\` weight=100 は runtime に加算されるため二重加算にはならない)

## テスト

- [x] \`dotnet build\`: 成功 (既存 CS0618 警告のみ)
- [x] 手動: 水着でパンスト/ニーハイ適用 → 食い込み解消スライダー操作 → title-back → 再ロードで肌が消えないことを確認

## 破壊的変更

なし。

---

## QA 確認項目

▼ どんな変更をして何を解決したか？

水着コスチューム時にもパンスト/ニーハイを適用できるようにし、食い込みや貫通をゲーム内 UI でリアルタイムに微調整できるようにした。タイトル戻り後の落ちと肌消失も解消。

▼ 既存影響あるか？

なし（CostumeChanger 機能を OFF にしている場合は影響なし）。水着ストッキング機能は初回から有効。

▼ 期待値

1. 正常: 水着キャラに CostumePicker から stocking タブで適用 → 即時反映、肌の食い込み/貫通なし
2. 正常: 微調整スライダー操作で stocking 押し出し量・肌押し込み量がライブ更新
3. 正常: タイトル戻り→セーブロードで肌が消えない
4. 異常: 水着以外（Uniform/Casual）では本機能の影響なし

▼ 確認内容

1. 水着衣装でパンスト/ニーハイを stocking タブから選択し、見た目が破綻しないこと
2. 設定パネルから 4 つのスライダーを動かし、押し出し/肌押し込みが視覚的に変化すること
3. リセットボタンで全スライダーが既定値（押し出し 0、他 1mm）に戻ること
4. タイトル戻り→セーブロードを繰り返し、肌が消えないこと（前バージョンの再現条件）