### PR TITLE
feat(steam): Steam外起動検出とSteam経由での自動再起動機能を追加

### DIFF
--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -62,6 +62,7 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigCostumeChangerEnabled;
     public static ConfigEntry<UnityEngine.InputSystem.Key> ConfigCostumeChangerHotkey;
     public static ConfigEntry<bool> ConfigRespectGameCostumeOverride;
+    public static ConfigEntry<bool> ConfigSteamLaunchCheck;
 
     private GameObject freeCamObject;
     private Camera freeCam;
@@ -249,8 +250,23 @@ public class Plugin : BaseUnityPlugin
             true,
             "true のとき、ゲーム本体が CostumeOverride を ForceXxx に設定している間は MOD 側の override を一時停止します。");
 
+        ConfigSteamLaunchCheck = Config.Bind(
+            "General",
+            "SteamLaunchCheck",
+            true,
+            "true にすると Steam 外から直接起動された場合に Steam 経由で自動的に再起動します。\n" +
+            "デバッグ目的でゲームフォルダに steam_appid.txt（内容: 3443820）を置くと、この機能をバイパスできます。");
+
         Logger = base.Logger;
         PatchLogger.Initialize(Logger);
+
+        // Steam 外起動を検出した場合は Steam 経由で再起動して即終了
+        if (ConfigSteamLaunchCheck.Value && SteamLaunchChecker.CheckAndRelaunchIfNeeded())
+        {
+            Application.Quit();
+            return;
+        }
+
         StartCoroutine(UpdateChecker.Check());
         var harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
         harmony.PatchAll();

--- a/BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs
+++ b/BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace BunnyGarden2FixMod.Utils;
@@ -49,11 +51,11 @@ internal static class SteamLaunchChecker
 
         try
         {
-            // 再起動試行を記録してループを防止
-            WriteRelaunchGuard();
-
             var url = $"steam://rungameid/{SteamAppId}";
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+
+            // Process.Start 成功後にガードを書き込む（失敗時は30秒ロックを回避）
+            WriteRelaunchGuard();
             return true;
         }
         catch (Exception ex)
@@ -78,7 +80,9 @@ internal static class SteamLaunchChecker
         try
         {
             var gameRoot = Path.GetDirectoryName(Application.dataPath) ?? string.Empty;
-            var checkDirs = new[] { gameRoot, Directory.GetCurrentDirectory() };
+            var checkDirs = new[] { gameRoot, Directory.GetCurrentDirectory() }
+                .Where(d => !string.IsNullOrEmpty(d))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
 
             foreach (var dir in checkDirs)
             {

--- a/BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs
+++ b/BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Utils;
+
+/// <summary>
+/// Steam 経由で起動されたかを判定し、Steam 外起動を検出した場合に
+/// <c>steam://rungameid/</c> で再起動してアプリを終了するユーティリティ。
+/// </summary>
+internal static class SteamLaunchChecker
+{
+    private const int SteamAppId = 3443820;
+
+    /// <summary>
+    /// 再起動ループを防ぐためのタイムスタンプファイル名。
+    /// 前回の再起動試行からこの秒数以内なら再試行をスキップする。
+    /// </summary>
+    private const int RelaunchGuardWindowSec = 30;
+    private static readonly string RelaunchGuardFile =
+        Path.Combine(Path.GetTempPath(), "bg2mod_steam_relaunch.tmp");
+
+    /// <summary>
+    /// Steam 外起動を検出した場合、Steam 経由で再起動する。
+    /// </summary>
+    /// <returns>
+    /// <c>true</c>: 再起動を試みた（呼び出し元は即座に <c>Application.Quit()</c> を
+    /// 呼び出して <c>Awake()</c> から return してください）。
+    /// <c>false</c>: Steam 経由確認済み／再起動スキップ（処理続行可）。
+    /// </returns>
+    public static bool CheckAndRelaunchIfNeeded()
+    {
+        if (IsLaunchedViaSteam())
+            return false;
+
+        // 再起動ループ防止: 直近 RelaunchGuardWindowSec 秒以内に試行済みならスキップ
+        if (IsRelaunchGuardActive())
+        {
+            PatchLogger.LogWarning(
+                "[SteamLaunchChecker] Steam 外起動を検出しましたが、直近の再起動試行から " +
+                $"{RelaunchGuardWindowSec} 秒が経過していないためスキップします。");
+            return false;
+        }
+
+        PatchLogger.LogWarning(
+            $"[SteamLaunchChecker] Steam 経由で起動されていません。" +
+            $"Steam 経由で再起動します (AppID: {SteamAppId})...");
+
+        try
+        {
+            // 再起動試行を記録してループを防止
+            WriteRelaunchGuard();
+
+            var url = $"steam://rungameid/{SteamAppId}";
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogError(
+                $"[SteamLaunchChecker] Steam 経由での再起動に失敗しました: {ex.Message}");
+            return false;
+        }
+    }
+
+    // ── 判定ロジック ─────────────────────────────────────────────────────
+
+    private static bool IsLaunchedViaSteam()
+    {
+        // Steam は起動時に SteamAppId 環境変数をセットする
+        var envAppId = Environment.GetEnvironmentVariable("SteamAppId");
+        if (envAppId == SteamAppId.ToString())
+            return true;
+
+        // steam_appid.txt が存在し AppID が一致する場合はデバッグ起動として許容
+        // Steam 本体はカレントディレクトリを優先参照するためゲームルートと CWD を両方確認
+        try
+        {
+            var gameRoot = Path.GetDirectoryName(Application.dataPath) ?? string.Empty;
+            var checkDirs = new[] { gameRoot, Directory.GetCurrentDirectory() };
+
+            foreach (var dir in checkDirs)
+            {
+                var file = Path.Combine(dir, "steam_appid.txt");
+                if (!File.Exists(file))
+                    continue;
+
+                var content = File.ReadAllText(file).Trim();
+                if (content == SteamAppId.ToString())
+                {
+                    PatchLogger.LogInfo(
+                        $"[SteamLaunchChecker] steam_appid.txt を検出しました ({file})。デバッグ起動として許容します。");
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[SteamLaunchChecker] steam_appid.txt の確認中にエラー: {ex.Message}");
+        }
+
+        return false;
+    }
+
+    // ── 再起動ループ防止 ─────────────────────────────────────────────────
+
+    private static bool IsRelaunchGuardActive()
+    {
+        try
+        {
+            if (!File.Exists(RelaunchGuardFile))
+                return false;
+
+            var lastWrite = File.GetLastWriteTimeUtc(RelaunchGuardFile);
+            return (DateTime.UtcNow - lastWrite).TotalSeconds < RelaunchGuardWindowSec;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void WriteRelaunchGuard()
+    {
+        try
+        {
+            File.WriteAllText(RelaunchGuardFile, SteamAppId.ToString());
+        }
+        catch (Exception ex)
+        {
+            PatchLogger.LogWarning($"[SteamLaunchChecker] 再起動ガードファイルの書き込みに失敗しました: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Steam 外から直接 exe を起動すると起動画面で停止してしまう問題への対策として、起動時に Steam 経由であるかを判定し、非 Steam 起動を検出した場合は `steam://rungameid/3443820` 経由で再起動してプロセスを終了する機能を追加する。

## 主な変更点
### 機能追加
- **SteamLaunchChecker ユーティリティ新規作成** — `SteamAppId` 環境変数と `steam_appid.txt` の両方で Steam 経由起動を判定
- **非 Steam 起動時の自動再起動** — `steam://rungameid/3443820` を `Process.Start` で呼び出して Steam 経由再起動、元プロセスは `Application.Quit()` で終了
- **再起動ループ防止** — タイムスタンプ付き一時ファイル（`%TEMP%/bg2mod_steam_relaunch.tmp`、30秒ウィンドウ）で再試行ガード
- **デバッグ用バイパス** — ゲームフォルダに `steam_appid.txt`（内容: `3443820`）を置くとチェックをスキップ
- **設定項目追加** — `General > SteamLaunchCheck`（デフォルト: `true`）で機能を無効化可能

## 変更ファイル一覧
- `BunnyGarden2FixMod/Plugin.cs` - `ConfigSteamLaunchCheck` を追加、`Awake()` 先頭付近でチェックを実行
- `BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs` - 新規。判定・再起動・ガードロジックを実装

## 技術的な補足
- Steam 本体は `steam_appid.txt` をカレントディレクトリから参照するため、ゲームルート（`Application.dataPath` の親）と CWD の両方をチェックしている
- `WriteRelaunchGuard()` は `Process.Start` 成功後に呼び出す順序とした（失敗時に30秒ロックが残らないようにするため）
- `Process.Start` は `UseShellExecute = true` で `steam://` URL スキームを OS に解決させる

## レビューのポイント
- `BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs:52-66` - Steam 経由再起動の起動フローとエラー時のフォールバック挙動
- `BunnyGarden2FixMod/Utils/SteamLaunchChecker.cs:71-108` - Steam 経由起動判定ロジック（環境変数 + steam_appid.txt）
- `BunnyGarden2FixMod/Plugin.cs:263-268` - `Application.Quit()` 後に `return` することで Harmony 等の初期化をスキップしている点

## テスト
- [ ] 手動テスト実施内容:
  - エクスプローラーから直接 exe を起動 → Steam クライアント経由で再起動されることを確認
  - Steam クライアント経由で起動 → チェックが通過して通常起動することを確認
  - `steam_appid.txt` を配置した状態で直接起動 → バイパスされて通常起動することを確認
  - `SteamLaunchCheck = false` 設定で直接起動 → 再起動せず通常起動することを確認

## 破壊的変更
なし（デフォルト有効だが `SteamLaunchCheck = false` で従来挙動に戻せる）

---

## QA 確認項目

▼ どんな変更をして何を解決したか？
Steam 外から直接 exe を起動すると起動画面で止まる問題に対し、起動時に Steam 経由かを自動判定し、非 Steam 起動時は Steam クライアント経由で再起動するようにした。

▼ 既存影響あるか？
あり。Steam 経由で正しく起動している場合は何も変化しないが、Steam 外起動時はプロセスが一旦終了して Steam クライアント経由で再起動される。オフライン環境や Steam 未起動状態では再起動が失敗し元プロセスも終了する可能性があるため、`SteamLaunchCheck = false` で無効化できる経路を用意。

▼ 期待値
1. 正常なケース (Steam 経由起動): 通常どおりゲームが起動し、MOD が読み込まれる
2. 正常なケース (直接起動): Steam クライアント経由で再起動が走り、最終的にゲームが正常起動する
3. 正常なケース (steam_appid.txt 配置 + 直接起動): バイパスされ、そのまま通常起動する
4. 異常なケース (Steam 未インストール環境で直接起動): 再起動に失敗しエラーログが出る。30秒以内の再起動はガードによりスキップされる

▼ 確認内容
1. Steam ライブラリから起動して通常動作することを確認
2. ゲーム本体 exe を直接起動 → Steam クライアント経由で再起動されることを確認
3. `BepInEx/config/net.noeleve.BunnyGarden2FixMod.cfg` の `SteamLaunchCheck = false` にして直接起動 → 再起動が走らないことを確認
4. ゲームフォルダに `steam_appid.txt`（内容: `3443820`）を置いて直接起動 → バイパスされ通常起動することを確認
5. BepInEx ログで `[SteamLaunchChecker]` プレフィックスのメッセージが想定どおり出力されることを確認