### PR TITLE
ビルド警告（CS0618）の修正

### DIFF
--- a/BunnyGarden2FixMod/Patches/CostumeChanger/CostumeChangerPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/CostumeChangerPatch.cs
@@ -173,7 +173,7 @@ public static class CostumeChangerPatch
         {
             // includeInactive: true — Enter() が gameObject.SetActive(true) を呼ぶ前の
             // ロード中フェーズでも FittingRoom インスタンスを検出するために必要。
-            s_fittingRoomCache = Object.FindObjectOfType<FittingRoom>(true);
+            s_fittingRoomCache = Object.FindFirstObjectByType<FittingRoom>(FindObjectsInactive.Include);
         }
         // Unity の == null はシーン遷移で破棄された参照も null と判定する
         if (s_fittingRoomCache == null) return false;

--- a/BunnyGarden2FixMod/Patches/GambleAlwaysWinPatch.cs
+++ b/BunnyGarden2FixMod/Patches/GambleAlwaysWinPatch.cs
@@ -131,7 +131,7 @@ public static class GambleAlwaysWinPatch
         if (!Plugin.ConfigGambleAlwaysWinEnabled.Value) return winAmount;
         if (winAmount >= 0) return winAmount;
 
-        var gamble = Object.FindObjectOfType<Gamble>();
+        var gamble = Object.FindFirstObjectByType<Gamble>();
         if (gamble == null) return 0;
 
         var gambleParam = gamble.m_gambleParams.Get(gamble.m_rate);

--- a/BunnyGarden2FixMod/Utils/UpdateChecker.cs
+++ b/BunnyGarden2FixMod/Utils/UpdateChecker.cs
@@ -190,7 +190,7 @@ internal static class UpdateChecker
         tmp.color = color == default ? Color.white : color;
         tmp.alignment = TextAlignmentOptions.Center;
         tmp.fontStyle = bold ? FontStyles.Bold : FontStyles.Normal;
-        tmp.enableWordWrapping = false;
+        tmp.textWrappingMode = TextWrappingModes.NoWrap;
         tmp.overflowMode = TextOverflowModes.Overflow;
     }
 
@@ -232,7 +232,7 @@ internal static class UpdateChecker
         tmp.color = Color.white;
         tmp.alignment = TextAlignmentOptions.Center;
         tmp.fontStyle = FontStyles.Bold;
-        tmp.enableWordWrapping = false;
+        tmp.textWrappingMode = TextWrappingModes.NoWrap;
         tmp.overflowMode = TextOverflowModes.Overflow;
 
         return btn;

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Wardrobeパネル表示中、以下のキーで操作できます。
 | キー | デフォルト | 説明 |
 |------|-----------|------|
 | `Enabled` | `true` | `true` にすると F9 キーで UI 非表示設定パネルを開けるようにします |
-| `HideInSpecialScenes` | `true` | `true` にすると旅行シーン・告白シーンで所持金 UI を非表示にします |
+| `HideInSpecialScenes` | `true` | `true` にすると旅行シーン・ラストシーンで所持金 UI を非表示にします |
 | `HideButtonGuide` | `false` | `true` にすると画面下のボタンガイド（操作ヒント）を常時非表示にします |
 
 #### 操作方法（F9パネル）


### PR DESCRIPTION
ビルド警告（CS0618）の修正

【修正理由】
ビルド警告（CS0618）が発生していたため、最新のAPIへ置換しました。

【修正内容】
- FindObjectOfType<T>(true) 
  → FindFirstObjectByType<T>(FindObjectsInactive.Include) へ変更
- FindObjectOfType<T>() 
  → FindFirstObjectByType<T>() へ変更
- enableWordWrapping = false 
  → textWrappingMode = TextWrappingModes.NoWrap へ変更

【動作確認環境】
OS: WSL2 (Kernel 6.6.87.2)
.NET SDK: 10.0.203
