### PR TITLE
Refactor Plugin, add Frame Advance and Fast Forward

### DIFF
--- a/BunnyGarden2FixMod/ConfigMigration.cs
+++ b/BunnyGarden2FixMod/ConfigMigration.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using BepInEx.Configuration;
+using BunnyGarden2FixMod.Utils;
+using HarmonyLib;
+using UnityEngine.InputSystem;
+
+namespace BunnyGarden2FixMod;
+
+public static class ConfigMigration
+{
+    private readonly struct MigrationEntry(ConfigDefinition oldDef, ConfigDefinition newDef)
+    {
+        public ConfigDefinition OldDef { get; } = oldDef;
+        public ConfigDefinition NewDef { get; } = newDef;
+    }
+
+    private static readonly MigrationEntry[] Migrations =
+    [
+        // 第一
+        new(new("AntiAliasing", "AntiAliasingType"), new("Graphics", "AntiAliasingType")),
+        new(new("Camera", "ControllerToggleFixedFreeCam"), new("Camera", HotkeyConfig.GamepadKey("ToggleFixedFreeCam"))),
+        new(new("Camera", "ControllerToggleFreeCam"), new("Camera", HotkeyConfig.GamepadKey("ToggleFreeCam"))),
+        new(new("Camera", "ControllerToggleModifier"), new("Input", "ControllerModifier")),
+        new(new("Camera", "ControllerToggleScreenshot"), new("General", HotkeyConfig.GamepadKey("CaptureScreenshot"))),
+        new(new("Camera", "ScreenshotKey"), new("General", HotkeyConfig.KeyboardKey("CaptureScreenshot"))),
+        new(new("Camera", "ControllerToggleTimeStop"), new("Time", HotkeyConfig.GamepadKey("ToggleTimeStop"))),
+        new(new("Camera", "TimeStopToggleKey"), new("Time", HotkeyConfig.KeyboardKey("ToggleTimeStop"))),
+        new(new("Camera", "ControllerTriggerDeadzone"), new("Input", "ControllerTriggerDeadzone")),
+        new(new("CastOrder", "Enabled"), new("Cheat", "CastOrder")),
+        new(new("Cheat", "Enabled"), new("Cheat", "Likability")),
+        new(new("CostumeChanger", "Hotkey"), new("CostumeChanger", HotkeyConfig.KeyboardKey("Show"))),
+        new(new("Resolution", "Width"), new("Graphics", "Width")),
+        new(new("Resolution", "Height"), new("Graphics", "Height")),
+        new(new("Resolution", "FrameRate"), new("Graphics", "FrameRate")),
+        new(new("Resolution", "ExtraWidth"), new("Graphics", "ExtraWidth")),
+        new(new("Resolution", "ExtraHeight"), new("Graphics", "ExtraHeight")),
+    ];
+
+    public static void Migrate(ConfigFile config)
+    {
+        PatchLogger.LogInfo($"[{nameof(ConfigMigration)}] 設定の移行を開始します");
+        var previousSaveOnConfigSet = config.SaveOnConfigSet;
+        config.SaveOnConfigSet = false;
+
+        ArrayMigration(config);
+
+        config.Save();
+        config.SaveOnConfigSet = previousSaveOnConfigSet;
+        PatchLogger.LogInfo($"[{nameof(ConfigMigration)}] 設定の移行が完了しました");
+    }
+
+    private static void ArrayMigration(ConfigFile config)
+    {
+        // これは少しハッキーですが、エントリの移行と古いエントリの実際の削除を処理する最善の方法です
+        var orphanedEntries =
+            (Dictionary<ConfigDefinition, string>)
+            AccessTools.PropertyGetter(typeof(ConfigFile), "OrphanedEntries").Invoke(config, null);
+
+        if (orphanedEntries == null)
+        {
+            PatchLogger.LogWarning(
+                $"[{nameof(ConfigMigration)}] " +
+                $"移行のための「OrphanedEntries」にアクセスできませんでした。移行はスキップされます");
+            return;
+        }
+
+        foreach (var entry in Migrations)
+        {
+            // 古いエントリが存在しない場合、それはすでに移行されているか、
+            // そもそも存在しなかったことを意味するため、ログなしでスキップします
+            if (!orphanedEntries.TryGetValue(entry.OldDef, out var oldValue))
+                continue;
+
+            orphanedEntries.Remove(entry.OldDef);
+            PatchLogger.LogInfo($"[{nameof(ConfigMigration)}] 古い設定エントリを削除しました: {entry.OldDef}");
+
+            // 新しいエントリがすでに存在する場合、ユーザーがすでに手動で移行したか新しいエントリを変更したことを意味するため、
+            // さらにログなしでスキップします。
+            if (orphanedEntries.ContainsKey(entry.NewDef))
+                continue;
+
+            orphanedEntries.Add(entry.NewDef, oldValue);
+            PatchLogger.LogInfo(
+                $"[{nameof(ConfigMigration)}]" +
+                $"新しい設定エントリに移行しました: {entry.NewDef} = {oldValue}");
+        }
+    }
+}

--- a/BunnyGarden2FixMod/Patches/CastOrderUI/CastOrderController.cs
+++ b/BunnyGarden2FixMod/Patches/CastOrderUI/CastOrderController.cs
@@ -121,8 +121,8 @@ public class CastOrderController : MonoBehaviour
 
     private void Update()
     {
-        if (Plugin.ConfigCastOrderEnabled == null) return;
-        if (!Plugin.ConfigCastOrderEnabled.Value) return;
+        if (Plugin.ConfigCastOrder == null) return;
+        if (!Plugin.ConfigCastOrder.Value) return;
         if (m_view == null) return;
 
         var kb = Keyboard.current;

--- a/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
@@ -1,3 +1,4 @@
+using BunnyGarden2FixMod.Utils;
 using HarmonyLib;
 using UnityEngine.Rendering.Universal;
 
@@ -6,6 +7,15 @@ namespace BunnyGarden2FixMod.Patches;
 [HarmonyPatch(typeof(ChromaticAberration), nameof(ChromaticAberration.IsActive))]
 public static class ChromaticAberrationPatch
 {
+    private static bool Prepare()
+    {
+        PatchLogger.LogInfo(
+            $"[{nameof(ChromaticAberrationPatch)}] " +
+            $"{nameof(ChromaticAberration)}.{nameof(ChromaticAberration.IsActive)} " +
+            $"をパッチしました。");
+        return true;
+    }
+
     private static bool Prefix(ChromaticAberration __instance, ref bool __result)
     {
         if (!Plugin.ConfigDisableChromaticAberration.Value)

--- a/BunnyGarden2FixMod/Patches/ConversationChoiceCheatPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ConversationChoiceCheatPatch.cs
@@ -59,7 +59,7 @@ public static class ConversationChoiceCheatPatch
 
     private static void Postfix(ConversationChoice __instance)
     {
-        if (!Plugin.ConfigCheatEnabled.Value) return;
+        if (!Plugin.ConfigCheatLikability.Value) return;
         try
         {
             var shuffleTable = s_shuffleTableField.GetValue(__instance) as List<int>;

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
@@ -186,7 +186,7 @@ public class CostumePickerController : MonoBehaviour
         if (kb == null) return;
 
         // トグル
-        if (kb[Plugin.ConfigCostumeChangerHotkey.Value].wasPressedThisFrame)
+        if (Plugin.ConfigCostumeChangerShow.IsTriggered())
         {
             if (m_view.IsShown)
             {

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraController.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraController.cs
@@ -1,12 +1,14 @@
+using BunnyGarden2FixMod.Utils;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-namespace BunnyGarden2FixMod.Controllers;
+namespace BunnyGarden2FixMod.Patches.FreeCamera;
 
 public class FreeCameraController : MonoBehaviour
 {
     private const float ControllerLookScale = 18f;
     private const float StickDeadzoneSqr = 0.01f;
+    private const float ZRDeadzone = 0.05f;
     private float rotationH;
     private float rotationV;
     private bool useMouseView = true;
@@ -26,9 +28,6 @@ public class FreeCameraController : MonoBehaviour
 
     private void Update()
     {
-        if (Plugin.isFixedFreeCam)
-            return;
-
         float deltaTime = Time.unscaledDeltaTime;
 
         if (useMouseView && Mouse.current != null)
@@ -39,7 +38,7 @@ public class FreeCameraController : MonoBehaviour
             rotationV -= mouseDelta.y * sensitivity * deltaTime;
         }
 
-        Vector2 rightStick = Plugin.ReadControllerRightStick();
+        Vector2 rightStick = GamepadHelper.ReadRightStick();
         if (rightStick.sqrMagnitude > StickDeadzoneSqr)
         {
             float sensitivity = Plugin.ConfigSensitivity.Value * ControllerLookScale;
@@ -54,9 +53,9 @@ public class FreeCameraController : MonoBehaviour
         float speed = Plugin.ConfigSpeed.Value;
         if (Plugin.ConfigControllerEnabled.Value)
         {
-            if (Plugin.IsControllerButtonHeld(ControllerHotkeyButton.R))
+            if (GamepadHelper.IsButtonHeld(ControllerButton.R))
                 speed = Plugin.ConfigFastSpeed.Value;
-            else if (Plugin.IsControllerButtonHeld(ControllerHotkeyButton.L))
+            else if (GamepadHelper.IsButtonHeld(ControllerButton.L))
                 speed = Plugin.ConfigSlowSpeed.Value;
         }
 
@@ -76,24 +75,25 @@ public class FreeCameraController : MonoBehaviour
             if (Keyboard.current.dKey.isPressed || Keyboard.current.rightArrowKey.isPressed)
                 transform.position += speed * deltaTime * transform.right;
             if (Keyboard.current.qKey.isPressed)
-                transform.position += speed * deltaTime * Vector3.up;
+                transform.position += speed * deltaTime * transform.up;
             if (Keyboard.current.eKey.isPressed)
-                transform.position += speed * deltaTime * Vector3.down;
+                transform.position += speed * deltaTime * -transform.up;
         }
 
         if (Plugin.ConfigControllerEnabled.Value)
         {
-            Vector2 leftStick = Plugin.ReadControllerLeftStick();
+            Vector2 leftStick = GamepadHelper.ReadLeftStick();
             if (leftStick.sqrMagnitude > StickDeadzoneSqr)
             {
                 transform.position += speed * deltaTime * transform.forward * leftStick.y;
                 transform.position += speed * deltaTime * transform.right * leftStick.x;
             }
 
-            if (Plugin.IsControllerButtonHeld(ControllerHotkeyButton.ZR))
-                transform.position += speed * deltaTime * Vector3.up;
-            if (Plugin.IsControllerButtonHeld(ControllerHotkeyButton.ZL))
-                transform.position += speed * deltaTime * Vector3.down;
+
+            transform.position += speed * deltaTime *
+                Mathf.InverseLerp(ZRDeadzone, 1, GamepadHelper.ReadTrigger(ControllerButton.ZR)) * transform.up;
+            transform.position += speed * deltaTime *
+                Mathf.InverseLerp(ZRDeadzone, 1, GamepadHelper.ReadTrigger(ControllerButton.ZL)) * -transform.up;
         }
 
         if (Mouse.current != null)

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using GB;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.Rendering.Universal;
+
+namespace BunnyGarden2FixMod.Patches.FreeCamera;
+
+public class FreeCameraManager : MonoBehaviour
+{
+    public static bool IsActive { get; private set; } = false;
+    public static bool IsFixed { get; private set; } = false;
+
+    private Camera originalCam;
+    private GameObject freeCamObject;
+    private FreeCameraController controller;
+    private readonly Dictionary<EventSystem, bool> eventSystemNavigationStates = [];
+    private readonly Dictionary<Canvas, bool> canvasEnabledStates = [];
+    private bool isGameUiSuppressed;
+
+    public static FreeCameraManager Initialize(GameObject parent)
+        => parent.AddComponent<FreeCameraManager>();
+
+    private void OnEnable()
+    {
+        Plugin.GUICallback += GUICallback;
+    }
+
+    private void OnDisable()
+    {
+        Plugin.GUICallback -= GUICallback;
+        Deactivate();
+    }
+
+    private void Update()
+    {
+        if (Plugin.ConfigFreeCamToggle.IsTriggered())
+            ToggleFreeCam();
+
+        if (Plugin.ConfigFixedFreeCamToggle.IsTriggered())
+            ToggleFixedFreeCam();
+    }
+
+    private void ToggleFreeCam()
+    {
+        if (IsActive)
+            Deactivate();
+        else
+            Activate();
+    }
+
+    private void ToggleFixedFreeCam()
+    {
+        if (!IsActive)
+            return;
+        IsFixed = !IsFixed;
+        if (controller != null)
+            controller.enabled = !IsFixed;
+        RefreshGameUiSuppression(force: true);
+        Plugin.Logger.LogInfo($"フリーカメラ固定モード: {(IsFixed ? "ON" : "OFF")}");
+    }
+
+    private void Activate()
+    {
+        originalCam = Plugin.FindCurrentCamera();
+        if (originalCam == null)
+        {
+            IsActive = false;
+            return;
+        }
+
+        freeCamObject = new GameObject("BG2FreeCam");
+        var freeCam = freeCamObject.AddComponent<Camera>();
+        freeCam.CopyFrom(originalCam);
+        freeCamObject.transform.SetPositionAndRotation(
+            originalCam.transform.position,
+            originalCam.transform.rotation);
+
+        // URP ポストプロセス設定をコピー（CinemachineBrain には触らない）
+        CopyUrpCameraData(originalCam, freeCam);
+
+        controller = freeCamObject.AddComponent<FreeCameraController>();
+        freeCamObject.gameObject.AddComponent<AudioListener>();
+
+        originalCam.enabled = false;
+        if (originalCam.TryGetComponent<AudioListener>(out var listener))
+            listener.enabled = false;
+
+        Plugin.Logger.LogInfo("フリーカメラを作成しました");
+
+        IsActive = true;
+        RefreshGameUiSuppression(force: true);
+    }
+
+    public void Deactivate()
+    {
+        if (freeCamObject != null)
+        {
+            Destroy(freeCamObject);
+            freeCamObject = null;
+            controller = null;
+        }
+
+        if (originalCam != null)
+        {
+            originalCam.enabled = true;
+
+            if (originalCam.TryGetComponent<AudioListener>(out var listener))
+                listener.enabled = true;
+        }
+
+        IsActive = false;
+        IsFixed = false;
+        RefreshGameUiSuppression(force: true);
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+
+        Plugin.Logger.LogInfo($"フリーカメラを解除しました");
+    }
+
+    private static void CopyUrpCameraData(Camera src, Camera dst)
+    {
+        var srcData = src.GetUniversalAdditionalCameraData();
+        var dstData = dst.GetUniversalAdditionalCameraData();
+        if (srcData == null || dstData == null)
+            return;
+
+        dstData.renderPostProcessing = srcData.renderPostProcessing;
+        dstData.antialiasing = srcData.antialiasing;
+        dstData.antialiasingQuality = srcData.antialiasingQuality;
+        dstData.stopNaN = srcData.stopNaN;
+        dstData.dithering = srcData.dithering;
+        dstData.renderShadows = srcData.renderShadows;
+        dstData.volumeLayerMask = srcData.volumeLayerMask;
+        dstData.volumeTrigger = srcData.volumeTrigger;
+    }
+
+    public void RefreshGameUiSuppression(bool force = false)
+    {
+        bool shouldSuppress = IsActive && !IsFixed && !ShouldExposeGameUiDuringFreeCam();
+        if (!force && shouldSuppress == isGameUiSuppressed)
+            return;
+
+        isGameUiSuppressed = shouldSuppress;
+
+        EventSystem[] eventSystems = FindObjectsByType<EventSystem>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+        Canvas[] canvases = FindObjectsByType<Canvas>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+
+        if (!shouldSuppress)
+        {
+            foreach (var pair in eventSystemNavigationStates)
+            {
+                if (pair.Key != null)
+                    pair.Key.sendNavigationEvents = pair.Value;
+            }
+
+            eventSystemNavigationStates.Clear();
+
+            foreach (var pair in canvasEnabledStates)
+            {
+                if (pair.Key != null)
+                    pair.Key.enabled = pair.Value;
+            }
+
+            canvasEnabledStates.Clear();
+            return;
+        }
+
+        foreach (var eventSystem in eventSystems)
+        {
+            if (eventSystem == null)
+                continue;
+
+            if (!eventSystemNavigationStates.ContainsKey(eventSystem))
+                eventSystemNavigationStates[eventSystem] = eventSystem.sendNavigationEvents;
+
+            eventSystem.sendNavigationEvents = false;
+            eventSystem.SetSelectedGameObject(null);
+        }
+
+        if (!Plugin.ConfigHideGameUiInFreeCam.Value)
+            return;
+
+        foreach (var canvas in canvases)
+        {
+            if (!ShouldHideCanvas(canvas))
+                continue;
+
+            if (!canvasEnabledStates.ContainsKey(canvas))
+                canvasEnabledStates[canvas] = canvas.enabled;
+
+            canvas.enabled = false;
+        }
+    }
+
+    private bool ShouldHideCanvas(Canvas canvas)
+    {
+        if (canvas == null)
+            return false;
+
+        if (freeCamObject != null && canvas.transform.IsChildOf(freeCamObject.transform))
+            return false;
+
+        return canvas.renderMode != RenderMode.WorldSpace;
+    }
+
+    private static bool ShouldExposeGameUiDuringFreeCam()
+    {
+        var gbSystem = GBSystem.Instance;
+        if (gbSystem == null)
+            return false;
+
+        if (gbSystem.IsInConfirmQuit || gbSystem.IsPauseMenuActive())
+            return true;
+
+        var confirmDialog = gbSystem.GetConfirmDialog();
+        return confirmDialog != null && confirmDialog.IsActive();
+    }
+
+    private void GUICallback()
+    {
+        if (!IsActive)
+            return;
+
+        GUI.color = Color.white;
+        GUILayout.Label(
+            "Move: Arrow/WASD or Left Stick, Up/Down: E/Q or ZR/ZL, Look: Mouse or Right Stick, Speed: Shift/Ctrl or R/L");
+        GUI.color = Color.green;
+        GUILayout.Label($"Free Camera: ON ({Plugin.ConfigFreeCamToggle}=OFF)");
+        GUI.color = Color.yellow;
+        GUILayout.Label($"Fixed Mode: {(IsFixed ? "ON" : "OFF")} ({Plugin.ConfigFixedFreeCamToggle}=TOGGLE)");
+        GUI.color = Color.white;
+    }
+}

--- a/BunnyGarden2FixMod/Patches/PurchasableItemCheatPatch.cs
+++ b/BunnyGarden2FixMod/Patches/PurchasableItemCheatPatch.cs
@@ -39,7 +39,7 @@ public static class PurchasableItemCheatPatch
 
     private static void Postfix(PurchasableItem __instance, PurchasableParam purchasableParam)
     {
-        if (!Plugin.ConfigCheatEnabled.Value) return;
+        if (!Plugin.ConfigCheatLikability.Value) return;
         try
         {
             if (GBSystem.Instance == null) return;

--- a/BunnyGarden2FixMod/Patches/TimeController.cs
+++ b/BunnyGarden2FixMod/Patches/TimeController.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace BunnyGarden2FixMod.Patches;
+
+public class TimeController : MonoBehaviour
+{
+    private bool fastForward;
+    private bool stop = false;
+    private int frames;
+
+    public static TimeController Initialize(GameObject parent)
+        => parent.AddComponent<TimeController>();
+
+    private void OnEnable()
+    {
+        Plugin.GUICallback += GUICallback;
+    }
+
+    private void OnDisable()
+    {
+        Plugin.GUICallback -= GUICallback;
+        Time.timeScale = 1f;
+        stop = false;
+    }
+
+    private void Update()
+    {
+        fastForward = Plugin.ConfigFastForward.IsHeld();
+
+        if (Plugin.ConfigTimeStopToggle.IsTriggered())
+            stop = !stop;
+
+        if (Plugin.ConfigFrameAdvance.IsTriggered())
+        {
+            stop = true;
+            frames = 1;
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (frames > 0)
+            Time.timeScale = 1f;
+        else if (stop)
+            Time.timeScale = 0f;
+        else if (fastForward)
+            Time.timeScale = Plugin.ConfigFastForwardSpeed.Value;
+        else
+            Time.timeScale = 1f;
+
+        frames = Mathf.Max(0, frames - 1);
+    }
+
+    private void GUICallback()
+    {
+        if (!stop)
+            return;
+
+        GUI.color = Color.cyan;
+        GUILayout.Label($"Time Stop: ON ({Plugin.ConfigTimeStopToggle}=OFF)");
+        GUILayout.Label($"Frame Advance: ({Plugin.ConfigFrameAdvance})");
+        GUILayout.Label($"Fast Forward: ({Plugin.ConfigFastForward})");
+        GUI.color = Color.white;
+    }
+}

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -40,55 +40,83 @@ public enum ChekiImageFormat
 public class Plugin : BaseUnityPlugin
 {
     private static Plugin Instance;
-    public static ConfigEntry<int> ConfigWidth;
-    public static ConfigEntry<int> ConfigHeight;
-    public static ConfigEntry<int> ConfigExtraWidth;
-    public static ConfigEntry<int> ConfigExtraHeight;
-    public static ConfigEntry<bool> ConfigExtraActive;
-    public static ConfigEntry<int> ConfigFrameRate;
-    public static ConfigEntry<AntiAliasingType> ConfigAntiAliasing;
-    public static ConfigEntry<bool> ConfigDisableChromaticAberration;
+
+    // Animation
+    public static ConfigEntry<bool> ConfigMoreTalkReactions;
+
+    // Appearance
+    public static ConfigEntry<bool> ConfigDisableStockings;
+
+    // Camera
     public static ConfigEntry<float> ConfigSensitivity;
     public static ConfigEntry<float> ConfigSpeed;
     public static ConfigEntry<float> ConfigFastSpeed;
     public static ConfigEntry<float> ConfigSlowSpeed;
-    public static ConfigEntry<bool> ConfigMoreTalkReactions;
-    public static ConfigEntry<float> ConfigControllerTriggerDeadzone;
     public static ConfigEntry<bool> ConfigHideGameUiInFreeCam;
-    public static ConfigEntry<bool> ConfigCheatEnabled;
-    public static ConfigEntry<bool> ConfigUltimateSurvivorEnabled;
+    public static ConfigEntry<bool> ConfigControllerEnabled;
+    public static HotkeyConfig ConfigFixedFreeCamToggle;
+    public static HotkeyConfig ConfigFreeCamToggle;
+
+    // Cheat
+    public static ConfigEntry<bool> ConfigCastOrder;
     public static ConfigEntry<bool> ConfigGambleAlwaysWinEnabled;
-    public static ConfigEntry<bool> ConfigDisableStockings;
-    public static ConfigEntry<bool> ConfigContinueVoiceOnTap;
+    public static ConfigEntry<bool> ConfigCheatLikability;
+    public static ConfigEntry<bool> ConfigUltimateSurvivorEnabled;
+
+    // Cheki
     public static ConfigEntry<bool> ConfigChekiHighResEnabled;
-    public static ConfigEntry<int> ConfigChekiSize;
     public static ConfigEntry<ChekiImageFormat> ConfigChekiFormat;
     public static ConfigEntry<int> ConfigChekiJpgQuality;
-    public static ConfigEntry<bool> ConfigEndingChekiSlideshow;
-    public static ConfigEntry<bool> ConfigCastOrderEnabled;
-    public static ConfigEntry<bool> ConfigControllerEnabled;
-    public static ConfigEntry<ControllerButton> ConfigControllerModifier;
-    public static HotkeyConfig ConfigOverlayToggle;
-    public static HotkeyConfig ConfigFreeCamToggle;
-    public static HotkeyConfig ConfigFixedFreeCamToggle;
-    public static HotkeyConfig ConfigTimeStopToggle;
-    public static HotkeyConfig ConfigFrameAdvance;
-    public static HotkeyConfig ConfigFastForward;
-    public static ConfigEntry<float> ConfigFastForwardSpeed;
-    public static HotkeyConfig ConfigCaptureScreenshot;
+    public static ConfigEntry<int> ConfigChekiSize;
+
+    // Conversation
+    public static ConfigEntry<bool> ConfigContinueVoiceOnTap;
+
+    // CostumeChanger
     public static ConfigEntry<bool> ConfigCostumeChangerEnabled;
-    public static ConfigEntry<UnityEngine.InputSystem.Key> ConfigCostumeChangerHotkey;
+    public static HotkeyConfig ConfigCostumeChangerShow;
     public static ConfigEntry<bool> ConfigRespectGameCostumeOverride;
-    public static ConfigEntry<bool> ConfigSteamLaunchCheck;
-    public static ConfigEntry<bool> ConfigHideUIEnabled;
-    public static ConfigEntry<bool> ConfigHideMoneyInSpecialScenes;
-    public static ConfigEntry<bool> ConfigHideButtonGuide;
-    public static ConfigEntry<bool> ConfigHideLikabilityGauge;
     public static ConfigEntry<bool> ConfigSwimWearStocking;
     public static ConfigEntry<float> ConfigStockingOffset;
     public static ConfigEntry<float> ConfigStockingSkinShrink;
     public static ConfigEntry<float> ConfigStockingSkinFalloffRadius;
     public static ConfigEntry<float> ConfigStockingShapeFalloffRadius;
+
+    // Ending
+    public static ConfigEntry<bool> ConfigEndingChekiSlideshow;
+
+    // General
+    public static HotkeyConfig ConfigCaptureScreenshot;
+    public static ConfigEntry<bool> ConfigSteamLaunchCheck;
+    public static HotkeyConfig ConfigOverlayToggle;
+
+    // Graphics
+    public static ConfigEntry<int> ConfigWidth;
+    public static ConfigEntry<int> ConfigHeight;
+    public static ConfigEntry<int> ConfigExtraWidth;
+    public static ConfigEntry<int> ConfigExtraHeight;
+    public static ConfigEntry<int> ConfigFrameRate;
+    public static ConfigEntry<AntiAliasingType> ConfigAntiAliasing;
+    public static ConfigEntry<bool> ConfigDisableChromaticAberration;
+
+    // HideUI
+    public static ConfigEntry<bool> ConfigHideUIEnabled;
+    public static ConfigEntry<bool> ConfigHideMoneyInSpecialScenes;
+    public static ConfigEntry<bool> ConfigHideButtonGuide;
+    public static ConfigEntry<bool> ConfigHideLikabilityGauge;
+
+    // Input
+    public static ConfigEntry<float> ConfigControllerTriggerDeadzone;
+    public static ConfigEntry<ControllerButton> ConfigControllerModifier;
+
+    // Internal
+    public static ConfigEntry<bool> ConfigExtraActive;
+
+    // Time
+    public static HotkeyConfig ConfigTimeStopToggle;
+    public static HotkeyConfig ConfigFrameAdvance;
+    public static HotkeyConfig ConfigFastForward;
+    public static ConfigEntry<float> ConfigFastForwardSpeed;
 
     internal static event Action GUICallback;
 
@@ -106,27 +134,31 @@ public class Plugin : BaseUnityPlugin
     private void Awake()
     {
         Instance = this;
+        Logger = base.Logger;
+        PatchLogger.Initialize(Logger);
+        ConfigMigration.Migrate(Config);
+
         ConfigWidth = Config.Bind(
-            "Resolution",
+            "Graphics",
             "Width",
             1920,
             "解像度の幅（横）を指定します");
 
         ConfigHeight = Config.Bind(
-            "Resolution",
+            "Graphics",
             "Height",
             1080,
             "解像度の高さ（縦）を指定します");
 
         ConfigExtraWidth = Config.Bind(
-            "Resolution",
+            "Graphics",
             "ExtraWidth",
             2560,
             "ゲーム内 OptionMenu の DISPLAY 項目に追加される拡張解像度（ウィンドウモード）の幅。\n" +
             "既定 2560（WQHD）。16:9 を推奨。");
 
         ConfigExtraHeight = Config.Bind(
-            "Resolution",
+            "Graphics",
             "ExtraHeight",
             1440,
             "ゲーム内 OptionMenu の DISPLAY 項目に追加される拡張解像度（ウィンドウモード）の高さ。\n" +
@@ -141,13 +173,13 @@ public class Plugin : BaseUnityPlugin
             "手動変更しないでください。");
 
         ConfigFrameRate = Config.Bind(
-            "Resolution",
+            "Graphics",
             "FrameRate",
             60,
             "フレームレート上限を指定します。-1にすると上限を撤廃します。");
 
         ConfigAntiAliasing = Config.Bind(
-            "AntiAliasing",
+            "Graphics",
             "AntiAliasingType",
             AntiAliasingType.MSAA8x,
             "アンチエイリアシングの種類を指定します。右の方ほど画質が良くなりますが、動作が重くなります。Off / FXAA / TAA / MSAA2x / MSAA4x / MSAA8x");
@@ -189,7 +221,7 @@ public class Plugin : BaseUnityPlugin
             "true にすると、バーの背景キャスト2人の会話リアクションモーションがより多様になります。");
 
         ConfigControllerTriggerDeadzone = Config.Bind(
-            "Camera",
+            "Input",
             "ControllerTriggerDeadzone",
             0.35f,
             "フリーカメラで ZL/ZR を押下扱いにするしきい値。トリガーの遊びやドリフトがある場合は上げてください。");
@@ -208,7 +240,7 @@ public class Plugin : BaseUnityPlugin
 
         ConfigControllerModifier = Config.Bind(
             "Input",
-            "ControllerToggleModifier",
+            "ControllerModifier",
             ControllerButton.Select,
             "コントローラ入力修飾ボタン。");
 
@@ -322,9 +354,9 @@ public class Plugin : BaseUnityPlugin
             true,
             "true にするとエンディング中に撮影済みのチェキをスライドショーで表示します。");
 
-        ConfigCastOrderEnabled = Config.Bind(
+        ConfigCastOrder = Config.Bind(
+            "Cheat",
             "CastOrder",
-            "Enabled",
             false,
             "true にするとバーに入る前にキャストの出勤順序を変更できます。\n" +
             "F1 キーで編集モードを開始し、数字キー（1〜5）でキャストを選択・入れ替えます。");
@@ -341,9 +373,9 @@ public class Plugin : BaseUnityPlugin
             false,
             "true にするとギャンブルで負けなくなります。");
 
-        ConfigCheatEnabled = Config.Bind(
+        ConfigCheatLikability = Config.Bind(
             "Cheat",
-            "Enabled",
+            "Likability",
             false,
             "true にすると会話選択肢・ドリンク・フードの正解をゲーム内に表示します。\n" +
             "【会話選択肢】選択肢テキストの先頭に記号が追加されます。\n" +
@@ -360,11 +392,12 @@ public class Plugin : BaseUnityPlugin
             true,
             "true にすると衣装変更 UI とパッチを有効化します。");
 
-        ConfigCostumeChangerHotkey = Config.Bind(
+        ConfigCostumeChangerShow = new HotkeyConfig(Config,
             "CostumeChanger",
-            "Hotkey",
+            "Show",
             Key.F7,
-            "衣装変更 UI の表示トグルキー（UnityEngine.InputSystem.Key enum 名で指定）。");
+            ControllerButton.None,
+            "衣装変更 UI の表示トグルキー。");
 
         ConfigRespectGameCostumeOverride = Config.Bind(
             "CostumeChanger",
@@ -453,9 +486,6 @@ public class Plugin : BaseUnityPlugin
                 "距離 0 で blendShape 効果 0、半径以上で 100%。境界（ウエスト等）の段差を解消する。\n" +
                 "0 で無効化（blendShape 効果は全頂点 100%）。デフォルト 0.001 (1mm)。",
                 new BepInEx.Configuration.AcceptableValueRange<float>(0f, 0.01f)));
-
-        Logger = base.Logger;
-        PatchLogger.Initialize(Logger);
 
         // Steam 外起動を検出した場合は Steam 経由で再起動して即終了
         if (ConfigSteamLaunchCheck.Value && SteamLaunchChecker.CheckAndRelaunchIfNeeded())
@@ -618,27 +648,6 @@ public class Plugin : BaseUnityPlugin
 
             isCapturingScreenshot = false;
         }
-    }
-
-    /// <summary>
-    /// 旧セクションのエントリが config ファイルに存在すれば値を読み取って辞書から削除し、値を返す。
-    /// 存在しない場合は <paramref name="defaultValue"/> をそのまま返す。
-    /// <para>
-    /// 使用パターン: 旧セクション削除後に同名キーを新セクションで <c>Config.Bind</c> すると、
-    /// 新セクション側がファイルにまだなければ <paramref name="defaultValue"/> がデフォルトとして
-    /// 採用される（= 旧値を引き継ぐ）。2回目以降は旧キーが存在しないため素通りし、
-    /// 新セクション既存ファイル値がそのまま使われる。
-    /// </para>
-    /// </summary>
-    private static T ReadAndRemoveOldEntry<T>(BepInEx.Configuration.ConfigFile config, string section, string key, T defaultValue)
-    {
-        var def = new BepInEx.Configuration.ConfigDefinition(section, key);
-        if (!config.ContainsKey(def)) return defaultValue;
-        var entry = (BepInEx.Configuration.ConfigEntry<T>)config[def];
-        T value = entry.Value;
-        config.Remove(def);
-        PatchLogger.LogInfo($"[Config] マイグレーション: [{section}].{key} = {value}");
-        return value;
     }
 }
 

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -1,24 +1,18 @@
-using BepInEx;
-using BepInEx.Configuration;
-using BepInEx.Logging;
-using System;
-using System.IO;
-
 #if BIE6
 using BepInEx.Unity.Mono;
 #endif
 
-using BunnyGarden2FixMod.Controllers;
+using System;
+using System.IO;
+using System.Linq;
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.Logging;
 using BunnyGarden2FixMod.Utils;
 using GB;
 using HarmonyLib;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.Controls;
-using UnityEngine.InputSystem.DualShock;
-using UnityEngine.Rendering.Universal;
-using UnityEngine.EventSystems;
 
 namespace BunnyGarden2FixMod;
 
@@ -42,21 +36,6 @@ public enum ChekiImageFormat
     JPG,
 }
 
-public enum ControllerHotkeyButton
-{
-    None,
-    A,
-    B,
-    X,
-    Y,
-    L,
-    R,
-    ZL,
-    ZR,
-    Start,
-    Select,
-}
-
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
 public class Plugin : BaseUnityPlugin
 {
@@ -76,8 +55,6 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigMoreTalkReactions;
     public static ConfigEntry<float> ConfigControllerTriggerDeadzone;
     public static ConfigEntry<bool> ConfigHideGameUiInFreeCam;
-    public static ConfigEntry<Key> ConfigTimeStopToggleKey;
-    public static ConfigEntry<Key> ConfigScreenshotKey;
     public static ConfigEntry<bool> ConfigCheatEnabled;
     public static ConfigEntry<bool> ConfigUltimateSurvivorEnabled;
     public static ConfigEntry<bool> ConfigGambleAlwaysWinEnabled;
@@ -90,11 +67,15 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<bool> ConfigEndingChekiSlideshow;
     public static ConfigEntry<bool> ConfigCastOrderEnabled;
     public static ConfigEntry<bool> ConfigControllerEnabled;
-    public static ConfigEntry<ControllerHotkeyButton> ConfigControllerModifier;
-    public static ConfigEntry<ControllerHotkeyButton> ConfigControllerFreeCamToggle;
-    public static ConfigEntry<ControllerHotkeyButton> ConfigControllerFixedFreeCamToggle;
-    public static ConfigEntry<ControllerHotkeyButton> ConfigControllerTimeStopToggle;
-    public static ConfigEntry<ControllerHotkeyButton> ConfigControllerScreenshotToggle;
+    public static ConfigEntry<ControllerButton> ConfigControllerModifier;
+    public static HotkeyConfig ConfigOverlayToggle;
+    public static HotkeyConfig ConfigFreeCamToggle;
+    public static HotkeyConfig ConfigFixedFreeCamToggle;
+    public static HotkeyConfig ConfigTimeStopToggle;
+    public static HotkeyConfig ConfigFrameAdvance;
+    public static HotkeyConfig ConfigFastForward;
+    public static ConfigEntry<float> ConfigFastForwardSpeed;
+    public static HotkeyConfig ConfigCaptureScreenshot;
     public static ConfigEntry<bool> ConfigCostumeChangerEnabled;
     public static ConfigEntry<UnityEngine.InputSystem.Key> ConfigCostumeChangerHotkey;
     public static ConfigEntry<bool> ConfigRespectGameCostumeOverride;
@@ -109,25 +90,16 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<float> ConfigStockingSkinFalloffRadius;
     public static ConfigEntry<float> ConfigStockingShapeFalloffRadius;
 
-    private GameObject freeCamObject;
-    private Camera freeCam;
-    private Camera originalCam;
-    private FreeCameraController controller;
-    private readonly Dictionary<EventSystem, bool> eventSystemNavigationStates = new();
-    private readonly Dictionary<Canvas, bool> canvasEnabledStates = new();
-    private bool isGameUiSuppressed;
-    private float previousTimeScale = 1f;
-    private bool isFreeCamOverlayVisible = true;
+    internal static event Action GUICallback;
+
+    private Patches.FreeCamera.FreeCameraManager freeCamera;
+    private bool isOverlayVisible = true;
     private bool isCapturingScreenshot;
     private static float suppressGameInputUntilUnscaledTime = -1f;
     private const float ControllerShortcutSuppressDuration = 0.18f;
 
     private static readonly string ScreenshotDirectory = Path.Combine(Paths.BepInExRootPath, "screenshots",
         MyPluginInfo.PLUGIN_GUID);
-
-    public static bool isFreeCamActive = false;
-    public static bool isFixedFreeCam = false;
-    public static bool isTimeStopped = false;
 
     internal new static ManualLogSource Logger;
 
@@ -228,53 +200,72 @@ public class Plugin : BaseUnityPlugin
             true,
             "true にするとフリーカメラ中にゲーム本体の UI(Canvas) を非表示にします。");
 
-        ConfigTimeStopToggleKey = Config.Bind(
-            "Camera",
-            "TimeStopToggleKey",
-            Key.T,
-            "フリーカメラ中の時間停止 ON/OFF に使うキーボードキー。既定 T。");
-
-        ConfigScreenshotKey = Config.Bind(
-            "Camera",
-            "ScreenshotKey",
-            Key.P,
-            "フリーカメラ中のスクリーンショット保存に使うキーボードキー。既定 P。");
-
         ConfigControllerEnabled = Config.Bind(
             "Camera",
             "ControllerEnabled",
             true,
-            "true にするとフリーカメラの切り替えと操作にゲームパッド入力を使用できます。");
+            "true にするとフリーカメラの操作にゲームパッド入力を使用できます。");
 
         ConfigControllerModifier = Config.Bind(
-            "Camera",
+            "Input",
             "ControllerToggleModifier",
-            ControllerHotkeyButton.Select,
-            "フリーカメラ切り替え用コントローラ修飾ボタン。既定 Select。");
+            ControllerButton.Select,
+            "コントローラ入力修飾ボタン。");
 
-        ConfigControllerFreeCamToggle = Config.Bind(
-            "Camera",
-            "ControllerToggleFreeCam",
-            ControllerHotkeyButton.Y,
-            "フリーカメラ ON/OFF に使うコントローラボタン。既定 Y。");
+        ConfigOverlayToggle = new HotkeyConfig(Config,
+            "General",
+            "ToggleOverlay",
+            Key.F12,
+            ControllerButton.Start,
+            "ガイドオーバーレイの表示/非表示を切り替えるホットキー。");
 
-        ConfigControllerFixedFreeCamToggle = Config.Bind(
+        ConfigFreeCamToggle = new HotkeyConfig(Config,
             "Camera",
-            "ControllerToggleFixedFreeCam",
-            ControllerHotkeyButton.X,
-            "フリーカメラ固定 ON/OFF に使うコントローラボタン。既定 X。");
+            "ToggleFreeCam",
+            Key.F5,
+            ControllerButton.Y,
+            "フリーカメラ ON/OFF に使うホットキー。");
 
-        ConfigControllerTimeStopToggle = Config.Bind(
+        ConfigFixedFreeCamToggle = new HotkeyConfig(Config,
             "Camera",
-            "ControllerToggleTimeStop",
-            ControllerHotkeyButton.B,
-            "フリーカメラ中の時間停止 ON/OFF に使うコントローラボタン。既定 B。");
+            "ToggleFixedFreeCam",
+            Key.F6,
+            ControllerButton.X,
+            "フリーカメラ固定 ON/OFF に使うホットキー。");
 
-        ConfigControllerScreenshotToggle = Config.Bind(
-            "Camera",
-            "ControllerToggleScreenshot",
-            ControllerHotkeyButton.A,
-            "フリーカメラ中のスクリーンショット保存に使うコントローラボタン。既定 A。修飾ボタンと同時押しです。");
+        ConfigTimeStopToggle = new HotkeyConfig(Config,
+            "Time",
+            "ToggleTimeStop",
+            Key.T,
+            ControllerButton.B,
+            "時間停止 ON/OFF に使うホットキー。");
+
+        ConfigFrameAdvance = new HotkeyConfig(Config,
+            "Time",
+            "FrameAdvance",
+            Key.F,
+            ControllerButton.None,
+            "1フレーム進めるホットキー。これを押すと、1フレームだけ時間が進みます。");
+
+        ConfigFastForward = new HotkeyConfig(Config,
+            "Time",
+            "FastForward",
+            Key.G,
+            ControllerButton.None,
+            "時間を早送りするホットキー。これを押すと、時間が通常より速く進みます。");
+
+        ConfigFastForwardSpeed = Config.Bind(
+            "Time",
+            "FastForwardSpeed",
+            10f,
+            "時間を早送りするホットキーを押している間の時間の進む速さの倍率。");
+
+        ConfigCaptureScreenshot = new HotkeyConfig(Config,
+            "General",
+            "CaptureScreenshot",
+            Key.P,
+            ControllerButton.A,
+            "スクリーンショット保存に使うホットキー。");
 
         ConfigDisableStockings = Config.Bind(
             "Appearance",
@@ -372,7 +363,7 @@ public class Plugin : BaseUnityPlugin
         ConfigCostumeChangerHotkey = Config.Bind(
             "CostumeChanger",
             "Hotkey",
-            UnityEngine.InputSystem.Key.F7,
+            Key.F7,
             "衣装変更 UI の表示トグルキー（UnityEngine.InputSystem.Key enum 名で指定）。");
 
         ConfigRespectGameCostumeOverride = Config.Bind(
@@ -482,6 +473,8 @@ public class Plugin : BaseUnityPlugin
         Patches.CostumeChanger.CostumeChangerPatch.Initialize(gameObject);
         Patches.HideMoneyUI.HideMoneyUIController.Initialize(gameObject);
         Patches.CostumeChanger.StockingsDonorLoader.Initialize(gameObject);
+        freeCamera = Patches.FreeCamera.FreeCameraManager.Initialize(gameObject);
+        Patches.TimeController.Initialize(gameObject);
         PatchLogger.LogInfo($"プラグイン起動: {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION}");
         PatchLogger.LogInfo($"解像度パッチを適用しました: {Plugin.ConfigWidth.Value}x{Plugin.ConfigHeight.Value}");
         PatchLogger.LogInfo($"アンチエイリアシング設定: {Plugin.ConfigAntiAliasing.Value}");
@@ -489,8 +482,6 @@ public class Plugin : BaseUnityPlugin
 
     private void OnDestroy()
     {
-        DisableTimeStopIfNeeded();
-
         if (ReferenceEquals(Instance, this))
             Instance = null;
     }
@@ -500,134 +491,31 @@ public class Plugin : BaseUnityPlugin
         if (Keyboard.current?[Key.F4].wasPressedThisFrame == true)
             Config.Reload();
 
-        bool ctrlPressed = Keyboard.current?.leftCtrlKey.isPressed == true || Keyboard.current?.rightCtrlKey.isPressed == true;
+        if (ConfigOverlayToggle.IsTriggered())
+            ToggleOverlay();
 
-        if (ctrlPressed && Keyboard.current?[Key.F5].wasPressedThisFrame == true)
-            ToggleFreeCamOverlay();
-        else if (Keyboard.current?[Key.F5].wasPressedThisFrame == true)
-            ToggleFreeCam();
-
-        if (Keyboard.current?[Key.F6].wasPressedThisFrame == true)
-            ToggleFixedFreeCam();
-
-        if (isFreeCamActive && Keyboard.current?[ConfigTimeStopToggleKey.Value].wasPressedThisFrame == true)
-            ToggleTimeStop();
-
-        if (isFreeCamActive && Keyboard.current?[ConfigScreenshotKey.Value].wasPressedThisFrame == true)
-            CaptureFreeCamScreenshot();
-
-        RefreshGameUiSuppression();
-
-        if (!ConfigControllerEnabled.Value)
-            return;
-
-        if (IsControllerComboTriggered(ConfigControllerModifier.Value, ConfigControllerFreeCamToggle.Value))
-        {
-            SuppressGameInputTemporarily();
-            ToggleFreeCam();
-        }
-
-        if (isFreeCamActive &&
-            IsControllerComboTriggered(ConfigControllerModifier.Value, ConfigControllerFixedFreeCamToggle.Value))
-        {
-            SuppressGameInputTemporarily();
-            ToggleFixedFreeCam();
-        }
-
-        if (isFreeCamActive && IsControllerComboTriggered(ConfigControllerModifier.Value, ControllerHotkeyButton.Start))
-        {
-            SuppressGameInputTemporarily();
-            ToggleFreeCamOverlay();
-        }
-
-        if (isFreeCamActive && !isFixedFreeCam &&
-            IsControllerComboTriggered(ConfigControllerModifier.Value, ConfigControllerTimeStopToggle.Value))
-        {
-            SuppressGameInputTemporarily();
-            ToggleTimeStop();
-        }
-
-        if (isFreeCamActive &&
-            IsControllerComboTriggered(ConfigControllerModifier.Value, ConfigControllerScreenshotToggle.Value))
-        {
-            SuppressGameInputTemporarily();
-            CaptureFreeCamScreenshot();
-        }
+        if (ConfigCaptureScreenshot.IsTriggered())
+            CaptureScreenshot();
     }
 
     private void OnGUI()
     {
-        if (!isFreeCamActive || !isFreeCamOverlayVisible)
+        if (!isOverlayVisible || isCapturingScreenshot)
             return;
 
-        string controllerFreeCamLabel = GetControllerBindingLabel(ConfigControllerModifier.Value,
-            ConfigControllerFreeCamToggle.Value);
-        string controllerOverlayLabel = GetControllerBindingLabel(ConfigControllerModifier.Value,
-            ControllerHotkeyButton.Start);
-        string controllerFixedLabel = GetControllerBindingLabel(ConfigControllerModifier.Value,
-            ConfigControllerFixedFreeCamToggle.Value);
-        string controllerTimeStopLabel = GetControllerBindingLabel(ConfigControllerModifier.Value,
-            ConfigControllerTimeStopToggle.Value);
-        string controllerScreenshotLabel = GetControllerBindingLabel(ConfigControllerModifier.Value,
-            ConfigControllerScreenshotToggle.Value);
-
-        GUI.color = Color.green;
-        GUI.Label(new Rect(10, 10, 1200, 30),
-            $"Free Camera: ON (F5 / {controllerFreeCamLabel}=OFF, Ctrl+F5 / {controllerOverlayLabel}=HIDE)");
-        GUI.color = Color.yellow;
-        GUI.Label(new Rect(10, 40, 900, 30),
-            $"Fixed Mode: {(isFixedFreeCam ? "ON" : "OFF")} (F6 / {controllerFixedLabel}=TOGGLE)");
-        GUI.color = Color.cyan;
-        GUI.Label(new Rect(10, 70, 900, 30),
-            $"Time Stop: {(isTimeStopped ? "ON" : "OFF")} (T / {controllerTimeStopLabel}=TOGGLE)");
-        GUI.color = Color.magenta;
-        GUI.Label(new Rect(10, 100, 900, 30),
-            $"Screenshot: {ConfigScreenshotKey.Value} / {controllerScreenshotLabel}=SAVE PNG");
-        GUI.color = Color.white;
-        GUI.Label(new Rect(10, 130, 1300, 30),
-            "Move: Arrow/WASD or Left Stick, Up/Down: E/Q or ZR/ZL, Look: Mouse or Right Stick, Speed: Shift/Ctrl or R/L");
-        GUI.color = Color.white;
-    }
-
-    private void ToggleFreeCam()
-    {
-        isFreeCamActive = !isFreeCamActive;
-
-        if (isFreeCamActive)
-            CreateFreeCam();
-        else
-        {
-            DisableTimeStopIfNeeded();
-            DestroyFreeCam();
-            isFixedFreeCam = false;
-        }
-
-        RefreshGameUiSuppression(force: true);
-
-        PatchLogger.LogInfo($"フリーカメラ: {(isFreeCamActive ? "ON" : "OFF")}");
-    }
-
-    private void DisableFreeCamForSystemUi(string reason)
-    {
-        if (!isFreeCamActive)
-            return;
-
-        DisableTimeStopIfNeeded();
-        DestroyFreeCam();
-        isFreeCamActive = false;
-        isFixedFreeCam = false;
-        RefreshGameUiSuppression(force: true);
-        Cursor.lockState = CursorLockMode.None;
-        Cursor.visible = true;
-        PatchLogger.LogInfo($"フリーカメラを自動解除しました: {reason}");
+        GUILayout.BeginArea(new Rect(10, 10, Screen.width / 2, Screen.height - 10));
+        GUICallback?.Invoke();
+        GUILayout.EndArea();
     }
 
     internal static void DisableFreeCamForSystemUiIfNeeded(string reason)
     {
-        Instance?.DisableFreeCamForSystemUi(reason);
+        Instance?.freeCamera?.Deactivate();
+
+        PatchLogger.LogInfo($"フリーカメラを自動解除しました: {reason}");
     }
 
-    private static void SuppressGameInputTemporarily()
+    public static void SuppressGameInputTemporarily()
     {
         suppressGameInputUntilUnscaledTime = Time.unscaledTime + ControllerShortcutSuppressDuration;
     }
@@ -637,75 +525,50 @@ public class Plugin : BaseUnityPlugin
         return Time.unscaledTime < suppressGameInputUntilUnscaledTime;
     }
 
-    private void ToggleFixedFreeCam()
+    internal static Camera FindCurrentCamera()
     {
-        if (isFreeCamActive)
+        var mainCam = Camera.main;
+        if (mainCam != null)
         {
-            isFixedFreeCam = !isFixedFreeCam;
-            if (isFixedFreeCam)
-                DisableTimeStopIfNeeded();
-            RefreshGameUiSuppression(force: true);
-            PatchLogger.LogInfo($"フリーカメラ固定モード: {(isFixedFreeCam ? "ON" : "OFF")}");
-        }
-    }
-
-    private void ToggleFreeCamOverlay()
-    {
-        if (!isFreeCamActive)
-            return;
-
-        isFreeCamOverlayVisible = !isFreeCamOverlayVisible;
-        PatchLogger.LogInfo($"フリーカメラ表示: {(isFreeCamOverlayVisible ? "ON" : "OFF")}");
-    }
-
-    private void ToggleTimeStop()
-    {
-        if (!isFreeCamActive || isFixedFreeCam)
-            return;
-
-        if (isTimeStopped)
-        {
-            DisableTimeStopIfNeeded();
-            PatchLogger.LogInfo("時間停止: OFF");
-            return;
+            Plugin.Logger.LogInfo($"Camera.main = {mainCam.name}");
+            return mainCam;
         }
 
-        previousTimeScale = Time.timeScale;
-        Time.timeScale = 0f;
-        isTimeStopped = true;
-        PatchLogger.LogInfo("時間停止: ON");
+        // tag に頼らず depth 最大のカメラを代替として使用
+        var cam = Camera.allCameras.OrderByDescending(c => c.depth).FirstOrDefault();
+        if (cam == null)
+        {
+            Plugin.Logger.LogError("有効なカメラが見つかりません。");
+            return null;
+        }
+        Plugin.Logger.LogInfo($"代替カメラを使用: {cam.name}");
+
+        return cam;
     }
 
-    private void DisableTimeStopIfNeeded()
+    private void ToggleOverlay()
     {
-        if (!isTimeStopped)
-            return;
-
-        Time.timeScale = previousTimeScale;
-        isTimeStopped = false;
+        isOverlayVisible = !isOverlayVisible;
+        PatchLogger.LogInfo($"表示: {(isOverlayVisible ? "ON" : "OFF")}");
     }
 
-    private void CaptureFreeCamScreenshot()
+    private void CaptureScreenshot()
     {
-        if (!isFreeCamActive || freeCam == null || isCapturingScreenshot)
-            return;
-
-        StartCoroutine(CaptureFreeCamScreenshotCoroutine());
+        StartCoroutine(CaptureScreenshotCoroutine());
     }
 
-    private System.Collections.IEnumerator CaptureFreeCamScreenshotCoroutine()
+    private System.Collections.IEnumerator CaptureScreenshotCoroutine()
     {
         isCapturingScreenshot = true;
-        Camera captureCam = freeCam;
+        Camera captureCam = FindCurrentCamera();
         yield return new WaitForEndOfFrame();
 
-        if (!isFreeCamActive || captureCam == null)
+        if (captureCam == null)
         {
             isCapturingScreenshot = false;
             yield break;
         }
 
-        string path = null;
         RenderTexture rt = null;
         Texture2D tex = null;
         RenderTexture previousActive = RenderTexture.active;
@@ -717,10 +580,13 @@ public class Plugin : BaseUnityPlugin
             int height = Mathf.Max(1, captureCam.pixelHeight);
 
             Directory.CreateDirectory(ScreenshotDirectory);
-            path = Path.Combine(ScreenshotDirectory,
-                $"freecam_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png");
+            string path = Path.Combine(ScreenshotDirectory,
+                $"bg2_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png");
 
-            rt = new RenderTexture(width, height, 24, RenderTextureFormat.ARGB32);
+            rt = new RenderTexture(width, height, 24, RenderTextureFormat.ARGB32)
+            {
+                antiAliasing = 8
+            };
             tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
 
             captureCam.targetTexture = rt;
@@ -731,11 +597,11 @@ public class Plugin : BaseUnityPlugin
             tex.Apply(false, false);
 
             File.WriteAllBytes(path, ImageConversion.EncodeToPNG(tex));
-            PatchLogger.LogInfo($"フリーカメラスクリーンショットを保存しました: {path}");
+            PatchLogger.LogInfo($"スクリーンショットを保存しました: {path}");
         }
         catch (Exception ex)
         {
-            PatchLogger.LogError($"フリーカメラスクリーンショット保存失敗: {ex.Message}");
+            PatchLogger.LogError($"スクリーンショット保存失敗: {ex.Message}");
         }
         finally
         {
@@ -752,322 +618,6 @@ public class Plugin : BaseUnityPlugin
 
             isCapturingScreenshot = false;
         }
-    }
-
-    private void CreateFreeCam()
-    {
-        // シーン内の全カメラを診断ログ出力
-        var allCameras = Camera.allCameras;
-        PatchLogger.LogInfo($"[FreeCam診断] シーン内カメラ数: {allCameras.Length}");
-        foreach (var cam in allCameras)
-        {
-            var brain = cam.GetComponent("CinemachineBrain");
-            PatchLogger.LogInfo($"  - {cam.name} | tag={cam.tag} | depth={cam.depth} | enabled={cam.enabled} | CinemachineBrain={brain != null}");
-        }
-
-        originalCam = Camera.main;
-        if (originalCam == null)
-        {
-            // tag に頼らず depth 最大のカメラを代替として使用
-            foreach (var cam in allCameras)
-            {
-                if (originalCam == null || cam.depth > originalCam.depth)
-                    originalCam = cam;
-            }
-
-            if (originalCam == null)
-            {
-                PatchLogger.LogError("[FreeCam診断] 有効なカメラが見つかりません。フリーカメラを起動できません");
-                isFreeCamActive = false;
-                return;
-            }
-            PatchLogger.LogInfo($"[FreeCam診断] 代替カメラを使用: {originalCam.name}");
-        }
-        else
-        {
-            PatchLogger.LogInfo($"[FreeCam診断] Camera.main = {originalCam.name}");
-        }
-
-        freeCamObject = new GameObject("BG2FreeCam");
-        freeCam = freeCamObject.AddComponent<Camera>();
-        freeCam.CopyFrom(originalCam);
-        freeCamObject.transform.SetPositionAndRotation(
-            originalCam.transform.position,
-            originalCam.transform.rotation);
-
-        // URP ポストプロセス設定をコピー（CinemachineBrain には触らない）
-        CopyUrpCameraData(originalCam, freeCam);
-
-        controller = freeCamObject.AddComponent<FreeCameraController>();
-        freeCamObject.AddComponent<AudioListener>();
-
-        originalCam.enabled = false;
-        var originalListener = originalCam.GetComponent<AudioListener>();
-        if (originalListener != null)
-            originalListener.enabled = false;
-
-        PatchLogger.LogInfo("フリーカメラを作成しました");
-    }
-
-    private static void CopyUrpCameraData(Camera src, Camera dst)
-    {
-        var srcData = src.GetUniversalAdditionalCameraData();
-        var dstData = dst.GetUniversalAdditionalCameraData();
-        if (srcData == null || dstData == null)
-            return;
-
-        dstData.renderPostProcessing = srcData.renderPostProcessing;
-        dstData.antialiasing = srcData.antialiasing;
-        dstData.antialiasingQuality = srcData.antialiasingQuality;
-        dstData.stopNaN = srcData.stopNaN;
-        dstData.dithering = srcData.dithering;
-        dstData.renderShadows = srcData.renderShadows;
-        dstData.volumeLayerMask = srcData.volumeLayerMask;
-        dstData.volumeTrigger = srcData.volumeTrigger;
-    }
-
-    private void DestroyFreeCam()
-    {
-        if (freeCamObject != null)
-        {
-            Destroy(freeCamObject);
-            freeCamObject = null;
-            freeCam = null;
-            controller = null;
-        }
-
-        if (originalCam != null)
-        {
-            originalCam.enabled = true;
-
-            var originalListener = originalCam.GetComponent<AudioListener>();
-            if (originalListener != null)
-                originalListener.enabled = true;
-        }
-    }
-
-    private void RefreshGameUiSuppression(bool force = false)
-    {
-        bool shouldSuppress = isFreeCamActive && !isFixedFreeCam && !ShouldExposeGameUiDuringFreeCam();
-        if (!force && shouldSuppress == isGameUiSuppressed)
-            return;
-
-        isGameUiSuppressed = shouldSuppress;
-
-        EventSystem[] eventSystems = FindObjectsByType<EventSystem>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-        Canvas[] canvases = FindObjectsByType<Canvas>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-
-        if (!shouldSuppress)
-        {
-            foreach (var pair in eventSystemNavigationStates)
-            {
-                if (pair.Key != null)
-                    pair.Key.sendNavigationEvents = pair.Value;
-            }
-
-            eventSystemNavigationStates.Clear();
-
-            foreach (var pair in canvasEnabledStates)
-            {
-                if (pair.Key != null)
-                    pair.Key.enabled = pair.Value;
-            }
-
-            canvasEnabledStates.Clear();
-            return;
-        }
-
-        foreach (var eventSystem in eventSystems)
-        {
-            if (eventSystem == null)
-                continue;
-
-            if (!eventSystemNavigationStates.ContainsKey(eventSystem))
-                eventSystemNavigationStates[eventSystem] = eventSystem.sendNavigationEvents;
-
-            eventSystem.sendNavigationEvents = false;
-            eventSystem.SetSelectedGameObject(null);
-        }
-
-        if (!ConfigHideGameUiInFreeCam.Value)
-            return;
-
-        foreach (var canvas in canvases)
-        {
-            if (!ShouldHideCanvas(canvas))
-                continue;
-
-            if (!canvasEnabledStates.ContainsKey(canvas))
-                canvasEnabledStates[canvas] = canvas.enabled;
-
-            canvas.enabled = false;
-        }
-    }
-
-    private static bool ShouldExposeGameUiDuringFreeCam()
-    {
-        var gbSystem = GBSystem.Instance;
-        if (gbSystem == null)
-            return false;
-
-        if (gbSystem.IsInConfirmQuit || gbSystem.IsPauseMenuActive())
-            return true;
-
-        var confirmDialog = gbSystem.GetConfirmDialog();
-        return confirmDialog != null && confirmDialog.IsActive();
-    }
-
-    private bool ShouldHideCanvas(Canvas canvas)
-    {
-        if (canvas == null)
-            return false;
-
-        if (freeCamObject != null && canvas.transform.IsChildOf(freeCamObject.transform))
-            return false;
-
-        return canvas.renderMode != RenderMode.WorldSpace;
-    }
-
-    private static bool IsControllerComboTriggered(ControllerHotkeyButton modifier, ControllerHotkeyButton action)
-    {
-        if (action == ControllerHotkeyButton.None)
-            return false;
-
-        if (modifier == ControllerHotkeyButton.None || modifier == action)
-            return IsControllerButtonTriggered(action);
-
-        return IsControllerButtonPressing(modifier) && IsControllerButtonTriggered(action);
-    }
-
-    private static bool IsControllerButtonTriggered(ControllerHotkeyButton button)
-    {
-        return IsRawGamepadButtonTriggered(button);
-    }
-
-    private static bool IsControllerButtonPressing(ControllerHotkeyButton button)
-    {
-        return IsRawGamepadButtonPressing(button);
-    }
-
-    internal static bool IsControllerButtonHeld(ControllerHotkeyButton button)
-    {
-        if (!ConfigControllerEnabled.Value)
-            return false;
-
-        if (button == ControllerHotkeyButton.ZL || button == ControllerHotkeyButton.ZR)
-            return ReadControllerTriggerValue(button) >= ConfigControllerTriggerDeadzone.Value;
-
-        return IsControllerButtonPressing(button);
-    }
-
-    internal static Vector2 ReadControllerLeftStick()
-    {
-        return ReadRawGamepadStick(gamepad => gamepad.leftStick.ReadValue());
-    }
-
-    internal static Vector2 ReadControllerRightStick()
-    {
-        return ReadRawGamepadStick(gamepad => gamepad.rightStick.ReadValue());
-    }
-
-    internal static float ReadControllerTriggerValue(ControllerHotkeyButton button)
-    {
-        return ReadRawGamepadTrigger(button);
-    }
-
-    private static bool IsRawGamepadButtonTriggered(ControllerHotkeyButton button)
-    {
-        foreach (var gamepad in Gamepad.all)
-        {
-            var control = GetRawGamepadButton(gamepad, button);
-            if (control?.wasPressedThisFrame == true)
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsRawGamepadButtonPressing(ControllerHotkeyButton button)
-    {
-        foreach (var gamepad in Gamepad.all)
-        {
-            var control = GetRawGamepadButton(gamepad, button);
-            if (control?.isPressed == true)
-                return true;
-        }
-
-        return false;
-    }
-
-    private static Vector2 ReadRawGamepadStick(System.Func<Gamepad, Vector2> selector)
-    {
-        foreach (var gamepad in Gamepad.all)
-        {
-            Vector2 value = selector(gamepad);
-            if (value.sqrMagnitude > 0f)
-                return value;
-        }
-
-        return Vector2.zero;
-    }
-
-    private static float ReadRawGamepadTrigger(ControllerHotkeyButton button)
-    {
-        foreach (var gamepad in Gamepad.all)
-        {
-            float value = button switch
-            {
-                ControllerHotkeyButton.ZL => gamepad.leftTrigger.ReadValue(),
-                ControllerHotkeyButton.ZR => gamepad.rightTrigger.ReadValue(),
-                _ => 0f,
-            };
-
-            if (value > 0f)
-                return value;
-        }
-
-        return 0f;
-    }
-
-    private static ButtonControl GetRawGamepadButton(Gamepad gamepad, ControllerHotkeyButton button)
-    {
-        if (gamepad == null)
-            return null;
-
-        return button switch
-        {
-            ControllerHotkeyButton.A => gamepad.buttonSouth,
-            ControllerHotkeyButton.B => gamepad.buttonEast,
-            ControllerHotkeyButton.X => gamepad.buttonWest,
-            ControllerHotkeyButton.Y => gamepad.buttonNorth,
-            ControllerHotkeyButton.L => gamepad.leftShoulder,
-            ControllerHotkeyButton.R => gamepad.rightShoulder,
-            ControllerHotkeyButton.ZL => gamepad.leftTrigger,
-            ControllerHotkeyButton.ZR => gamepad.rightTrigger,
-            ControllerHotkeyButton.Start => gamepad.startButton,
-            ControllerHotkeyButton.Select => GetRawSelectButton(gamepad),
-            _ => null,
-        };
-    }
-
-    private static ButtonControl GetRawSelectButton(Gamepad gamepad)
-    {
-        var dualShockGamepad = gamepad as DualShockGamepad;
-        if (dualShockGamepad != null)
-            return dualShockGamepad.touchpadButton;
-
-        return gamepad.selectButton;
-    }
-
-    private static string GetControllerBindingLabel(ControllerHotkeyButton modifier, ControllerHotkeyButton action)
-    {
-        if (action == ControllerHotkeyButton.None)
-            return "Disabled";
-
-        if (modifier == ControllerHotkeyButton.None || modifier == action)
-            return action.ToString();
-
-        return $"{modifier}+{action}";
     }
 
     /// <summary>
@@ -1097,7 +647,7 @@ public class FreeCamInputDisablePatch
 {
     private static void Postfix(ref bool __result)
     {
-        if (Plugin.isFreeCamActive && !Plugin.isFixedFreeCam)
+        if (Patches.FreeCamera.FreeCameraManager.IsActive && !Patches.FreeCamera.FreeCameraManager.IsFixed)
             __result = true;
     }
 }
@@ -1139,7 +689,7 @@ public class FreeCamControllerShortcutInputSuppressionPatch
     [HarmonyPrefix]
     private static bool SuppressTriggeredRepeat(ref bool __result)
     {
-        if (!Plugin.isFreeCamActive || !Plugin.ShouldSuppressGameInput())
+        if (!Patches.FreeCamera.FreeCameraManager.IsActive || !Plugin.ShouldSuppressGameInput())
             return true;
 
         __result = false;
@@ -1150,7 +700,7 @@ public class FreeCamControllerShortcutInputSuppressionPatch
     [HarmonyPrefix]
     private static bool SuppressStick(InputAction stick, ref Vector2 __result)
     {
-        if (!Plugin.isFreeCamActive || !Plugin.ShouldSuppressGameInput())
+        if (!Patches.FreeCamera.FreeCameraManager.IsActive || !Plugin.ShouldSuppressGameInput())
             return true;
 
         if (stick?.activeControl?.device is not Gamepad)
@@ -1164,7 +714,7 @@ public class FreeCamControllerShortcutInputSuppressionPatch
     [HarmonyPrefix]
     private static bool SuppressCameraControl(ref Vector2 __result)
     {
-        if (!Plugin.isFreeCamActive || !Plugin.ShouldSuppressGameInput())
+        if (!Patches.FreeCamera.FreeCameraManager.IsActive || !Plugin.ShouldSuppressGameInput())
             return true;
 
         __result = Vector2.zero;
@@ -1173,7 +723,7 @@ public class FreeCamControllerShortcutInputSuppressionPatch
 
     private static bool TrySuppress(InputAction button, ref bool result)
     {
-        if (!Plugin.isFreeCamActive || !Plugin.ShouldSuppressGameInput())
+        if (!Patches.FreeCamera.FreeCameraManager.IsActive || !Plugin.ShouldSuppressGameInput())
             return true;
 
         if (button?.activeControl?.device is not Gamepad)

--- a/BunnyGarden2FixMod/Utils/GamepadHelper.cs
+++ b/BunnyGarden2FixMod/Utils/GamepadHelper.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
@@ -6,6 +7,21 @@ using UnityEngine.InputSystem.DualShock;
 #nullable enable
 
 namespace BunnyGarden2FixMod.Utils;
+
+public enum ControllerButton
+{
+    None,
+    A,
+    B,
+    X,
+    Y,
+    L,
+    R,
+    ZL,
+    ZR,
+    Start,
+    Select,
+}
 
 public static class GamepadHelper
 {
@@ -44,59 +60,38 @@ public static class GamepadHelper
 
     private static Vector2 ReadRawStick(System.Func<Gamepad, Vector2> selector)
     {
-        foreach (var gamepad in Gamepad.all)
-        {
-            Vector2 value = selector(gamepad);
-            if (value.sqrMagnitude > 0f)
-                return value;
-        }
-
-        return Vector2.zero;
+        return Gamepad.all
+            .Select(selector)
+            .FirstOrDefault(value => value.sqrMagnitude > 0f);
     }
 
     private static float ReadRawTrigger(ControllerButton button)
     {
-        foreach (var gamepad in Gamepad.all)
-        {
-            float value = button switch
+        return Gamepad.all
+            .Select(gamepad => button switch
             {
                 ControllerButton.ZL => gamepad.leftTrigger.ReadValue(),
                 ControllerButton.ZR => gamepad.rightTrigger.ReadValue(),
                 _ => 0f,
-            };
-
-            if (value > 0f)
-                return value;
-        }
-
-        return 0f;
+            })
+            .FirstOrDefault(value => value > 0f);
     }
 
     private static bool IsRawTriggered(ControllerButton button)
     {
-        foreach (var gamepad in Gamepad.all)
-        {
-            var control = GetRawGamepadButton(gamepad, button);
-            if (control?.wasPressedThisFrame == true)
-                return true;
-        }
-
-        return false;
+        return Gamepad.all
+            .Select(gamepad => GetRawGamepadButton(gamepad, button))
+            .Any(control => control?.wasPressedThisFrame == true);
     }
 
     private static bool IsRawHeld(ControllerButton button)
     {
-        foreach (var gamepad in Gamepad.all)
-        {
-            var control = GetRawGamepadButton(gamepad, button);
-            if (control?.isPressed == true)
-                return true;
-        }
-
-        return false;
+        return Gamepad.all
+            .Select(gamepad => GetRawGamepadButton(gamepad, button))
+            .Any(control => control?.isPressed == true);
     }
 
-    private static ButtonControl? GetRawGamepadButton(Gamepad gamepad, ControllerButton button)
+    private static ButtonControl? GetRawGamepadButton(Gamepad? gamepad, ControllerButton button)
     {
         if (gamepad == null)
             return null;

--- a/BunnyGarden2FixMod/Utils/GamepadHelper.cs
+++ b/BunnyGarden2FixMod/Utils/GamepadHelper.cs
@@ -1,0 +1,127 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.DualShock;
+
+#nullable enable
+
+namespace BunnyGarden2FixMod.Utils;
+
+public static class GamepadHelper
+{
+    internal static bool IsButtonHeld(ControllerButton button)
+    {
+        if (button == ControllerButton.ZL || button == ControllerButton.ZR)
+            return ReadTrigger(button) >= Plugin.ConfigControllerTriggerDeadzone.Value;
+
+        return IsHeld(button);
+    }
+
+    internal static Vector2 ReadLeftStick()
+    {
+        return ReadRawStick(gamepad => gamepad.leftStick.ReadValue());
+    }
+
+    internal static Vector2 ReadRightStick()
+    {
+        return ReadRawStick(gamepad => gamepad.rightStick.ReadValue());
+    }
+
+    internal static float ReadTrigger(ControllerButton button)
+    {
+        return ReadRawTrigger(button);
+    }
+
+    internal static bool IsTriggered(ControllerButton button)
+    {
+        return IsRawTriggered(button);
+    }
+
+    internal static bool IsHeld(ControllerButton button)
+    {
+        return IsRawHeld(button);
+    }
+
+    private static Vector2 ReadRawStick(System.Func<Gamepad, Vector2> selector)
+    {
+        foreach (var gamepad in Gamepad.all)
+        {
+            Vector2 value = selector(gamepad);
+            if (value.sqrMagnitude > 0f)
+                return value;
+        }
+
+        return Vector2.zero;
+    }
+
+    private static float ReadRawTrigger(ControllerButton button)
+    {
+        foreach (var gamepad in Gamepad.all)
+        {
+            float value = button switch
+            {
+                ControllerButton.ZL => gamepad.leftTrigger.ReadValue(),
+                ControllerButton.ZR => gamepad.rightTrigger.ReadValue(),
+                _ => 0f,
+            };
+
+            if (value > 0f)
+                return value;
+        }
+
+        return 0f;
+    }
+
+    private static bool IsRawTriggered(ControllerButton button)
+    {
+        foreach (var gamepad in Gamepad.all)
+        {
+            var control = GetRawGamepadButton(gamepad, button);
+            if (control?.wasPressedThisFrame == true)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsRawHeld(ControllerButton button)
+    {
+        foreach (var gamepad in Gamepad.all)
+        {
+            var control = GetRawGamepadButton(gamepad, button);
+            if (control?.isPressed == true)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static ButtonControl? GetRawGamepadButton(Gamepad gamepad, ControllerButton button)
+    {
+        if (gamepad == null)
+            return null;
+
+        return button switch
+        {
+            ControllerButton.A => gamepad.buttonSouth,
+            ControllerButton.B => gamepad.buttonEast,
+            ControllerButton.X => gamepad.buttonWest,
+            ControllerButton.Y => gamepad.buttonNorth,
+            ControllerButton.L => gamepad.leftShoulder,
+            ControllerButton.R => gamepad.rightShoulder,
+            ControllerButton.ZL => gamepad.leftTrigger,
+            ControllerButton.ZR => gamepad.rightTrigger,
+            ControllerButton.Start => gamepad.startButton,
+            ControllerButton.Select => GetRawSelectButton(gamepad),
+            _ => null,
+        };
+    }
+
+    private static ButtonControl GetRawSelectButton(Gamepad gamepad)
+    {
+        if (gamepad is DualShockGamepad dualShockGamepad)
+            return dualShockGamepad.touchpadButton;
+
+        return gamepad.selectButton;
+    }
+}

--- a/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
+++ b/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
@@ -1,0 +1,129 @@
+using BepInEx.Configuration;
+using UnityEngine.InputSystem;
+
+#nullable enable
+
+namespace BunnyGarden2FixMod.Utils;
+
+public enum ControllerButton
+{
+    None,
+    A,
+    B,
+    X,
+    Y,
+    L,
+    R,
+    ZL,
+    ZR,
+    Start,
+    Select,
+}
+
+
+public class HotkeyConfig
+{
+    public ConfigEntry<Key>? KeyConfig { get; }
+    public ConfigEntry<ControllerButton>? ButtonConfig { get; }
+
+    public HotkeyConfig(
+        ConfigFile config,
+        string section,
+        string key,
+        Key defaultKey,
+        ControllerButton defaultButton,
+        string description)
+    {
+        KeyConfig = config.Bind(section, $"{key}Key", defaultKey, $"{description} (Keyboard)");
+        ButtonConfig = config.Bind(section, $"{key}Button", defaultButton, $"{description} (Gamepad)");
+    }
+
+    public HotkeyConfig(
+        ConfigFile config,
+        string section,
+        string key,
+        Key defaultKey,
+        string description)
+    {
+        KeyConfig = config.Bind(section, $"{key}Key", defaultKey, $"{description} (Keyboard)");
+    }
+
+    public HotkeyConfig(
+        ConfigFile config,
+        string section,
+        string key,
+        ControllerButton defaultButton,
+        string description)
+    {
+        ButtonConfig = config.Bind(section, $"{key}Button", defaultButton, $"{description} (Gamepad)");
+    }
+
+    public override string ToString()
+    {
+        string? keyLabel = KeyConfig == null || KeyConfig.Value == Key.None ? null : KeyConfig.Value.ToString();
+        string? buttonLabel = GetControllerBindingLabel(Plugin.ConfigControllerModifier.Value, ButtonConfig?.Value);
+
+        if (keyLabel != null && buttonLabel != null)
+            return $"{keyLabel} / {buttonLabel}";
+
+        return keyLabel ?? buttonLabel ?? "Unbound";
+    }
+
+    public bool IsHeld()
+    {
+        if (KeyConfig != null && Keyboard.current?[KeyConfig.Value].isPressed == true)
+            return true;
+
+        if (ButtonConfig != null && GamepadHelper.IsHeld(Plugin.ConfigControllerModifier.Value) &&
+            GamepadHelper.IsHeld(ButtonConfig.Value))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool IsTriggered()
+    {
+        return IsKeyboardTriggered() || IsControllerTriggered();
+    }
+
+    public bool IsKeyboardTriggered()
+    {
+        return KeyConfig != null && Keyboard.current?[KeyConfig.Value].wasPressedThisFrame == true;
+    }
+
+    public bool IsControllerTriggered()
+    {
+        if (ButtonConfig != null &&
+            IsControllerComboTriggered(Plugin.ConfigControllerModifier.Value, ButtonConfig.Value))
+        {
+            Plugin.SuppressGameInputTemporarily();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string? GetControllerBindingLabel(ControllerButton modifier, ControllerButton? action)
+    {
+        if (action == null || action == ControllerButton.None)
+            return null;
+
+        if (modifier == ControllerButton.None || modifier == action)
+            return action.ToString();
+
+        return $"{modifier}+{action}";
+    }
+
+    private static bool IsControllerComboTriggered(ControllerButton modifier, ControllerButton action)
+    {
+        if (action == ControllerButton.None)
+            return false;
+
+        if (modifier == ControllerButton.None || modifier == action)
+            return GamepadHelper.IsTriggered(action);
+
+        return GamepadHelper.IsHeld(modifier) && GamepadHelper.IsTriggered(action);
+    }
+}

--- a/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
+++ b/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
@@ -5,22 +5,6 @@ using UnityEngine.InputSystem;
 
 namespace BunnyGarden2FixMod.Utils;
 
-public enum ControllerButton
-{
-    None,
-    A,
-    B,
-    X,
-    Y,
-    L,
-    R,
-    ZL,
-    ZR,
-    Start,
-    Select,
-}
-
-
 public class HotkeyConfig
 {
     public ConfigEntry<Key>? KeyConfig { get; }
@@ -34,8 +18,8 @@ public class HotkeyConfig
         ControllerButton defaultButton,
         string description)
     {
-        KeyConfig = config.Bind(section, $"{key}Key", defaultKey, $"{description} (Keyboard)");
-        ButtonConfig = config.Bind(section, $"{key}Button", defaultButton, $"{description} (Gamepad)");
+        KeyConfig = config.Bind(section, KeyboardKey(key), defaultKey, $"{description} (Keyboard)");
+        ButtonConfig = config.Bind(section, GamepadKey(key), defaultButton, $"{description} (Gamepad)");
     }
 
     public HotkeyConfig(
@@ -45,7 +29,7 @@ public class HotkeyConfig
         Key defaultKey,
         string description)
     {
-        KeyConfig = config.Bind(section, $"{key}Key", defaultKey, $"{description} (Keyboard)");
+        KeyConfig = config.Bind(section, KeyboardKey(key), defaultKey, $"{description} (Keyboard)");
     }
 
     public HotkeyConfig(
@@ -55,8 +39,12 @@ public class HotkeyConfig
         ControllerButton defaultButton,
         string description)
     {
-        ButtonConfig = config.Bind(section, $"{key}Button", defaultButton, $"{description} (Gamepad)");
+        ButtonConfig = config.Bind(section, GamepadKey(key), defaultButton, $"{description} (Gamepad)");
     }
+
+    public static string GamepadKey(string key) => $"{key}Button";
+
+    public static string KeyboardKey(string key) => $"{key}Key";
 
     public override string ToString()
     {


### PR DESCRIPTION
変更点がたくさんあるし、日本語が苦手なので英語で説明します。申し訳ありません。

Most of this PR is a refactor, trying to reign down some of the code complexity.

The Plugin class has been growing a lot and very fast, and it makes it more difficult to understand or change stuff.

There is too much code duplication in regards to input handling as well.

Several features are tied to the Free Camera even though they could work perfectly fine anyway.

The general UI overlay is hard-tied to the Plugin class so other classes can't use it.

I made the following changes to try to help this situation:

1. Added a static event to Plugin so other classes can draw to the UI overlay. Use GUILayout for this instead of just GUI so the layout is handled automatically.

2. Added a `HotkeyConfig` class which encapsulates a double keybind: one for keyboard and one for gamepad. 

  * It can be used to check for input and it'll check both keybinds.

  * It can be used to get a label for the keybind for both keybinds.

  * For Gamepad it also requires the modifier button to be held. I changed the modifier button so it's not part of the Free Camera but more global for Gamepad input.

3. General gamepad input code has been moved to a static `GamepadHelper` class.

4. Free Camera code has been split into a separate class, `FreeCameraManager`. It still relies on `FreeCameraController` but otherwise handles all FreeCam creation/deletion.

5. The Pause function has been decoupled from the Free Camera function, and extended with frame advance and fast forward. All three functions can have its keybind configured for both gamepad and keyboard.

6. The Screenshot function has been decoupled from the Free Camera function. Pressing the hotkey will save a screenshot using the active camera, free camera or not.

Smaller changes:

1. Updated free camera controller so up/down are transform relative just like the other directions. I think this is better. If your camera is already looking straight up or down, the up/down keybinds become useless otherwise, they just do the same thing as forward/back.

2. Also updated the free camera gamepad controls so the speed of going up/down depends on how much you press ZL/ZR. Full press is full speed, half a press is half speed, and so on.

3. Added antialiasing = 8 to the screenshot render texture as it was saving screenshots with no antialiasing in my tests...

4. Have the Plugin overlay not render when a screenshot is taken.

5. Some config entries mentioned the default value in the description, this is redundant because all config entries automatically show the default value so I removed those.

And finally, I did find it necessary to move a lot of config entries around for this... I know it's lame but I think it's a necessary change.

This would close #17 but I'm leaving it open for now just in case.

# AI翻訳で日本語版 (claudeくんありがとう)

このPRのほとんどはリファクタリングであり、コードの複雑さを抑えることを目的としています。
`Plugin`クラスは急速に肥大化しており、コードの理解や変更が困難になっています。
また、入力処理に関するコードの重複が多すぎます。
いくつかの機能はフリーカメラに紐づいていますが、本来は独立して動作できるはずです。
汎用UIオーバーレイが`Plugin`クラスに密結合しているため、他のクラスから利用できません。

この状況を改善するために、以下の変更を行いました：

1. `Plugin`に静的イベントを追加し、他のクラスがUIオーバーレイに描画できるようにしました。レイアウトを自動的に処理できるよう、`GUI`の代わりに`GUILayout`を使用します。
2. キーボード用とゲームパッド用の2つのキーバインドをカプセル化する`HotkeyConfig`クラスを追加しました。
   * 入力チェックに使用でき、両方のキーバインドを確認します。
   * 両方のキーバインドのラベル取得にも使用できます。
   * ゲームパッドでは、モディファイアボタンの押し続けが必要です。モディファイアボタンはフリーカメラ専用ではなく、ゲームパッド入力全体に対してグローバルなものに変更しました。
3. 汎用ゲームパッド入力コードを静的クラス`GamepadHelper`に移動しました。
4. フリーカメラのコードを別クラス`FreeCameraManager`に分離しました。`FreeCameraController`への依存は残りますが、フリーカメラの作成・削除はすべてこのクラスで処理します。
5. ポーズ機能をフリーカメラ機能から切り離し、フレームアドバンスと早送りを追加しました。3つの機能すべてで、ゲームパッドとキーボードの両方に対してキーバインドを設定できます。
6. スクリーンショット機能をフリーカメラ機能から切り離しました。ホットキーを押すと、フリーカメラの使用有無にかかわらず、アクティブなカメラでスクリーンショットを保存します。

細かい変更点：

1. フリーカメラコントローラーを更新し、上下移動が他の方向と同様にトランスフォーム相対になるようにしました。カメラがすでに真上や真下を向いている場合、上下キーバインドが前後と同じ動作になってしまうため、この方が良いと思います。
2. フリーカメラのゲームパッド操作も更新し、上下移動の速度がZL/ZRの押し込み量に連動するようにしました。フルプレスで最高速度、ハーフプレスで半速、といった具合です。
3. テストでアンチエイリアスなしのスクリーンショットが保存されていたため、スクリーンショットのレンダーテクスチャに`antialiasing = 8`を追加しました。
4. スクリーンショット撮影時にPluginのオーバーレイが表示されないようにしました。
5. 一部の設定項目の説明にデフォルト値が記載されていましたが、すべての設定項目には自動的にデフォルト値が表示されるため冗長であり、削除しました。

最後に、この変更に伴い多くの設定項目を移動する必要がありました。残念ではありますが、必要な変更だと考えています。
これにより issue #17 はクローズできますが、念のためしばらくオープンのままにしておきます。