### PR TITLE
Add screenshot scale option

### DIFF
--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -94,6 +94,7 @@ public class Plugin : BaseUnityPlugin
 
     // General
     public static HotkeyConfig ConfigCaptureScreenshot;
+    public static ConfigEntry<int> ConfigScreenshotScale;
 
     public static ConfigEntry<bool> ConfigSteamLaunchCheck;
     public static HotkeyConfig ConfigOverlayToggle;
@@ -318,6 +319,12 @@ public class Plugin : BaseUnityPlugin
             "フリーカメラ中にゲーム UI・MOD オーバーレイを写さずスクリーンショットを保存するホットキー。\n" +
             "BepInEx/screenshots フォルダに PNG で保存されます。\n" +
             "コントローラーの場合は ControllerModifier と同時押しが必要です。");
+
+        ConfigScreenshotScale = Config.Bind(
+            "General",
+            "ScreenshotScale",
+            1,
+            "スクリーンショットの解像度倍率。1 で通常のスクリーンショットと同じ解像度、2 で倍の解像度になります。");
 
         ConfigDisableStockings = Config.Bind(
             "Appearance",
@@ -629,65 +636,27 @@ public class Plugin : BaseUnityPlugin
 
     private System.Collections.IEnumerator CaptureScreenshotCoroutine()
     {
-        isCapturingScreenshot = true;
         Camera captureCam = FindCurrentCamera();
-        yield return new WaitForEndOfFrame();
-
         if (captureCam == null)
-        {
-            isCapturingScreenshot = false;
             yield break;
-        }
 
-        RenderTexture rt = null;
-        Texture2D tex = null;
-        RenderTexture previousActive = RenderTexture.active;
-        RenderTexture previousTarget = captureCam.targetTexture;
+        isCapturingScreenshot = true;
 
         try
         {
-            int width = Mathf.Max(1, captureCam.pixelWidth);
-            int height = Mathf.Max(1, captureCam.pixelHeight);
-
             Directory.CreateDirectory(ScreenshotDirectory);
-            string path = Path.Combine(ScreenshotDirectory,
-                $"bg2_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png");
-
-            rt = new RenderTexture(width, height, 24, RenderTextureFormat.ARGB32)
-            {
-                antiAliasing = 8
-            };
-            tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
-
-            captureCam.targetTexture = rt;
-            captureCam.Render();
-
-            RenderTexture.active = rt;
-            tex.ReadPixels(new Rect(0f, 0f, width, height), 0, 0);
-            tex.Apply(false, false);
-
-            File.WriteAllBytes(path, ImageConversion.EncodeToPNG(tex));
+            string path = Path.Combine(ScreenshotDirectory, $"bg2_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png");
+            ScreenCapture.CaptureScreenshot(path, ConfigScreenshotScale.Value);
             PatchLogger.LogInfo($"スクリーンショットを保存しました: {path}");
         }
         catch (Exception ex)
         {
             PatchLogger.LogError($"スクリーンショット保存失敗: {ex.Message}");
         }
-        finally
-        {
-            if (captureCam != null)
-                captureCam.targetTexture = previousTarget;
 
-            RenderTexture.active = previousActive;
-
-            if (rt != null)
-                Destroy(rt);
-
-            if (tex != null)
-                Destroy(tex);
-
-            isCapturingScreenshot = false;
-        }
+        // スクリーンショットがキャプチャされる前にオーバーレイを再表示しないよう、1フレーム待機します
+        yield return null;
+        isCapturingScreenshot = false;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
 | `ToggleOverlayButton` | `Start` | フリーカメラ操作ガイドオーバーレイの表示/非表示に使うコントローラーボタン（ControllerModifier と同時押し） |
 | `CaptureScreenshotKey` | `P` | フリーカメラ中にゲーム UI を写さずスクリーンショットを保存するキーボードキー |
 | `CaptureScreenshotButton` | `A` | 同上コントローラーボタン（ControllerModifier と同時押し） |
+| `ScreenshotScale` | `1` | スクリーンショットの解像度倍率 |
 | `SteamLaunchCheck` | `true` | `true` にすると Steam 外から直接起動された場合に Steam 経由で自動的に再起動します。デバッグ目的でゲームフォルダに `steam_appid.txt`（内容: `3443820`）を置くとこの機能をバイパスできます |
 
 フリーカメラは **F5** キーで ON/OFF、**F6** キーでカメラ固定のトグルができます。  


### PR DESCRIPTION
スクリーンショットのスケール設定を追加し、スクリーンショットのキャプチャ方法を変更しました。新しい方法ではゲームのUIも一緒にキャプチャされますが、フリーカメラを使用することでUIなしのスクリーンショットも引き続き撮影できます。また、プラグインのオーバーレイがスクリーンショットに映り込まないよう対処しました。

変更した理由は、以前の方法ではすべてのポストプロセッシングエフェクトがキャプチャされていなかったためです。

スクリーンショットのスケールを設定することで、7680x4320のスクリーンショットが撮影できました！ただし、サイズが20MBを超えるためここにはアップロードできませんが…