### PR TITLE
Add DepthOfFieldPatch

### DIFF
--- a/BunnyGarden2FixMod/Patches/DepthOfFieldPatch.cs
+++ b/BunnyGarden2FixMod/Patches/DepthOfFieldPatch.cs
@@ -1,0 +1,26 @@
+using BunnyGarden2FixMod.Utils;
+using HarmonyLib;
+using UnityEngine.Rendering.Universal;
+
+namespace BunnyGarden2FixMod.Patches;
+
+[HarmonyPatch(typeof(DepthOfField), nameof(DepthOfField.IsActive))]
+public static class DepthOfFieldPatch
+{
+    private static bool Prepare()
+    {
+        PatchLogger.LogInfo(
+            $"[{nameof(DepthOfFieldPatch)}] " +
+            $"{nameof(DepthOfField)}.{nameof(DepthOfField.IsActive)} " +
+            $"をパッチしました。");
+        return true;
+    }
+
+    private static bool Prefix(DepthOfField __instance, ref bool __result)
+    {
+        if (!Plugin.ConfigDisableDepthOfField.Value)
+            return true;
+        __result = false;
+        return false;
+    }
+}

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -107,6 +107,7 @@ public class Plugin : BaseUnityPlugin
     public static ConfigEntry<int> ConfigFrameRate;
     public static ConfigEntry<AntiAliasingType> ConfigAntiAliasing;
     public static ConfigEntry<bool> ConfigDisableChromaticAberration;
+    public static ConfigEntry<bool> ConfigDisableDepthOfField;
 
     // HideUI
     public static ConfigEntry<bool> ConfigHideUIEnabled;
@@ -201,6 +202,12 @@ public class Plugin : BaseUnityPlugin
             "DisableChromaticAberration",
             false,
             "true にすると色収差エフェクト(画面の端のほうがにじんで見える効果)を無効化します。");
+
+        ConfigDisableDepthOfField = Config.Bind(
+            "Graphics",
+            "DisableDepthOfField",
+            false,
+            "true にすると被写界深度エフェクト(画面の一部がぼやける効果)を無効化します。");
 
         ConfigSensitivity = Config.Bind(
             "Camera",

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | `FrameRate` | `60` | フレームレート上限。`-1` にすると上限を撤廃します |
 | `AntiAliasingType` | `MSAA8x` | アンチエイリアスの種類。`Off` / `FXAA` / `TAA` / `MSAA2x` / `MSAA4x` / `MSAA8x` から選択。右に行くほど高品質ですが重くなります |
 | `DisableChromaticAberration` | `false` | `true` にすると色収差エフェクト（画面の端がにじんで見える効果）を無効化します |
+| `DisableDepthOfField` | `false` | `true` にすると被写界深度エフェクト（画面の一部がぼやける効果）を無効化します |
 
 ### [Animation] アニメーション
 


### PR DESCRIPTION
これは、クロマティックアベレーション（色収差）のパッチと同様のものですが、代わりに被写界深度に適用したものです。

Vanilla (DoF ON)
<img width="1920" height="1080" alt="vanilla" src="https://github.com/user-attachments/assets/a5f3af5f-6fce-4ea3-bf86-093e24a6e0b0" />

Modded (DoF OFF)
<img width="1920" height="1080" alt="disabled" src="https://github.com/user-attachments/assets/0ad21f83-4bbb-4793-a221-cface1ce409a" />
