### PR TITLE
Fix skirt clipping during some animations

### DIFF
--- a/BunnyGarden2FixMod/Patches/FixAnimationClippingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/FixAnimationClippingPatch.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using BunnyGarden2FixMod.Utils;
+using GB.Scene;
+using HarmonyLib;
+using UnityEngine;
+using VLB;
+using static GB.Scene.CharacterHandle;
+
+namespace BunnyGarden2FixMod.Patches;
+
+[HarmonyPatch(typeof(CharacterHandle), nameof(CharacterHandle.PlayMotion))]
+public static class FixAnimationClippingPatch
+{
+    private static bool Prepare()
+    {
+        PatchLogger.LogInfo(
+            $"[{nameof(FixAnimationClippingPatch)}] " +
+            $"{nameof(CharacterHandle)}.{nameof(CharacterHandle.PlayMotion)} " +
+            $"をパッチしました。");
+        return true;
+    }
+
+    private class Fixer : MonoBehaviour
+    {
+        private static readonly Vector3 Offset = new(-0.01f, 0.02f, 0);
+
+        public bool IsActive { get; set; }
+
+        private Animator charAnimator;
+        private Transform skirtFixBoneLeft;
+        private Transform skirtFixBoneRight;
+
+        private Vector3 offsetValue;
+
+        public void SetUp(Animator animator)
+        {
+            charAnimator = animator;
+
+            if (skirtFixBoneLeft == null)
+                skirtFixBoneLeft = transform.Find("Root_skinJT/Pelvis_skinJT/Hip_skinJT/L_skirtD1_skinJT/L_skirtD2_skinJT");
+            if (skirtFixBoneRight == null)
+                skirtFixBoneRight = transform.Find("Root_skinJT/Pelvis_skinJT/Hip_skinJT/R_skirtD1_skinJT/R_skirtD2_skinJT");
+        }
+
+        private static Vector3 ExpDecay(Vector3 a, Vector3 b, float decay, float deltaTime)
+            => b + (a - b) * Mathf.Exp(-decay * deltaTime);
+
+        private void LateUpdate()
+        {
+            if (charAnimator == null || !charAnimator.isActiveAndEnabled)
+                return;
+
+            var goal = IsActive ? Offset : Vector3.zero;
+
+            // アニメーションの開始と終了時にオフセットが滑らかに変化するように指数関数的減衰を使用しています。
+            offsetValue = ExpDecay(offsetValue, goal, 3f, Time.deltaTime);
+
+            // アニメーションの特定のフレームでスカートがクリッピングするのを防ぐために、スカートのボーンに小さなオフセットを適用します。
+            // オフセットはLateUpdateで適用されるため、アニメーションが適用された後に位置を変更します。
+            if (skirtFixBoneLeft != null)
+                skirtFixBoneLeft.localPosition += offsetValue;
+            if (skirtFixBoneRight != null)
+                skirtFixBoneRight.localPosition += offsetValue;
+        }
+    }
+
+    private static readonly HashSet<MOTION> AffectedMotions =
+    [
+        MOTION.KNEEL_DOWN_START,
+        MOTION.KNEEL_DOWN_LP,
+        MOTION.CHECK_SHELVES,
+    ];
+
+    private static void Postfix(CharacterHandle __instance, MOTION __0, float __1)
+    {
+        if (!Plugin.ConfigFixAnimationClipping.Value || __instance.m_chara == null)
+            return;
+
+        var fixer = __instance.m_chara.GetOrAddComponent<Fixer>();
+        fixer.SetUp(__instance.m_animator);
+        fixer.IsActive = AffectedMotions.Contains(__0);
+    }
+}

--- a/BunnyGarden2FixMod/Patches/TalkReactionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/TalkReactionPatch.cs
@@ -30,16 +30,16 @@ public static class TalkReactionPatch
             MOTION.BOW,
         ];
 
-        private MOTION _lastMotion = MOTION._DUMMY;
+        private MOTION lastMotion = MOTION._DUMMY;
 
         public MOTION GetNextMotion()
         {
-            _lastMotion = _lastMotion switch
+            lastMotion = lastMotion switch
             {
                 MOTION.KNEEL_DOWN_START => MOTION.KNEEL_DOWN_END,
                 _ => TalkReactionMotions[Random.RandomRangeInt(0, TalkReactionMotions.Length)]
             };
-            return _lastMotion;
+            return lastMotion;
         }
     }
 
@@ -52,7 +52,7 @@ public static class TalkReactionPatch
         if (!__instance.m_chara.activeSelf
             || GBSystem.Instance.IsConversateChar(__instance.m_id)
             || new[] { MOTION.WALK, MOTION.SERVING_FOOD, MOTION.MOPPING_FLOOR, MOTION.CHECK_SHELVES }
-                .Any(motion => __instance.m_animator.GetCurrentAnimatorStateInfo(2).IsName(MOTION_NAME[(int)motion]))
+                .Any(motion => __instance.isSameAnimation(Layer.LAYER_BASE, MOTION_NAME[(int)motion]))
             || !__instance.m_enableTalkReactionMotion)
         {
             return false;

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -44,6 +44,7 @@ public class Plugin : BaseUnityPlugin
 
     // Animation
     public static ConfigEntry<bool> ConfigMoreTalkReactions;
+    public static ConfigEntry<bool> ConfigFixAnimationClipping;
 
     // Appearance
     public static ConfigEntry<bool> ConfigDisableStockings;
@@ -231,6 +232,12 @@ public class Plugin : BaseUnityPlugin
             "MoreTalkReactions",
             false,
             "true にすると、バーの背景キャスト2人の会話リアクションモーションがより多様になります。");
+
+        ConfigFixAnimationClipping = Config.Bind(
+            "Animation",
+            "FixAnimationClipping",
+            true,
+            "true にすると、一部のモーションでキャストのスカートが体にめり込むクリッピングを修正します。");
 
         ConfigControllerTriggerDeadzone = Config.Bind(
             "Input",


### PR DESCRIPTION
会話リアクション中にスカートがクリッピングされる問題を修正する、小さなアニメーションパッチです。
修正前：
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/15d908e3-0020-4ce3-951e-8fb675bab576" />
修正後：
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/cdea1f1c-0374-4736-8dc0-40493e831ccc" />
