### PR TITLE
refactor(plugin): Plugin.ConfigX 転送プロパティを削除し Configs.X 直接参照に統一

### DIFF
--- a/BunnyGarden2FixMod/Patches/AddBunnyDrinksToDrinkSetParamsPatch.cs
+++ b/BunnyGarden2FixMod/Patches/AddBunnyDrinksToDrinkSetParamsPatch.cs
@@ -30,7 +30,7 @@ internal static class AddBunnyDrinksToDrinkSetParamsPatch
 
     private static void Postfix(ref List<DrinkParam> __result)
     {
-        if (!Plugin.ConfigBunnyDrinksEnabled.Value) return;
+        if (!Configs.BunnyDrinksEnabled.Value) return;
         if (__result == null) return;
 
         // 全ドリンクリストを取得

--- a/BunnyGarden2FixMod/Patches/AntiAliasingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/AntiAliasingPatch.cs
@@ -18,7 +18,7 @@ public static class AntiAliasingSetterPatch
 {
     private static void Prefix(ref AntialiasingMode value)
     {
-        value = Plugin.ConfigAntiAliasing.Value switch
+        value = Configs.AntiAliasing.Value switch
         {
             AntiAliasingType.Off => AntialiasingMode.None,
             AntiAliasingType.FXAA => AntialiasingMode.FastApproximateAntialiasing,
@@ -40,11 +40,11 @@ public static class AntiAliasingSetterPatch
 public static class MsaaSetupPatch
 {
     private static void Postfix()
-        => LiveConfigBinding.BindAndApply(Plugin.ConfigAntiAliasing, Apply);
+        => LiveConfigBinding.BindAndApply(Configs.AntiAliasing, Apply);
 
     private static void Apply()
     {
-        int msaaSamples = Plugin.ConfigAntiAliasing.Value switch
+        int msaaSamples = Configs.AntiAliasing.Value switch
         {
             AntiAliasingType.MSAA2x => 2,
             AntiAliasingType.MSAA4x => 4,

--- a/BunnyGarden2FixMod/Patches/CalcFullScreenResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CalcFullScreenResolutionPatch.cs
@@ -28,8 +28,8 @@ public class CalcFullScreenResolutionPatch
 {
     private static bool Prefix(ref ValueTuple<int, int, bool> __result)
     {
-        int configW = Plugin.ConfigWidth.Value;
-        int configH = Plugin.ConfigHeight.Value;
+        int configW = Configs.Width.Value;
+        int configH = Configs.Height.Value;
         Resolution mon = Screen.currentResolution;
 
         if (GameplayFullscreenUltrawideSupport.ShouldUseNativeFullscreen())

--- a/BunnyGarden2FixMod/Patches/CastOrderUI/CastOrderController.cs
+++ b/BunnyGarden2FixMod/Patches/CastOrderUI/CastOrderController.cs
@@ -121,8 +121,8 @@ public class CastOrderController : MonoBehaviour
 
     private void Update()
     {
-        if (Plugin.ConfigCastOrder == null) return;
-        if (!Plugin.ConfigCastOrder.Value) return;
+        if (Configs.CastOrder == null) return;
+        if (!Configs.CastOrder.Value) return;
         if (m_view == null) return;
 
         var kb = Keyboard.current;

--- a/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiItemLoadHiResPatch.cs
@@ -17,7 +17,7 @@ namespace BunnyGarden2FixMod.Patches;
 /// <para>
 /// <b>フォールバック:</b>
 /// <list type="bullet">
-///   <item><see cref="Plugin.ConfigChekiHighResEnabled"/> が false → 何もしない（vanilla 320）</item>
+///   <item><see cref="Configs.ChekiHighResEnabled"/> が false → 何もしない（vanilla 320）</item>
 ///   <item><c>gameData.IsChekiValid(slot)</c> が false → 何もしない（vanilla の鍵アイコン表示）</item>
 ///   <item>ExSave に該当エントリが無い → 何もしない（vanilla 320）</item>
 ///   <item>ペイロード破損（未対応 magic / LoadImage 失敗 / サイズ範囲外）→ 何もしない（警告ログのみ）</item>
@@ -59,7 +59,7 @@ public static class ChekiItemLoadHiResPatch
 
     private static void Postfix(ChekiItem __instance, GameData gameData, int slot)
     {
-        if (!Plugin.ConfigChekiHighResEnabled.Value) return;
+        if (!Configs.ChekiHighResEnabled.Value) return;
         if (gameData == null) return;
 
         // slot 範囲外は受け付けない（異常系 / 悪意のある .exmod 防御）。

--- a/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
@@ -105,7 +105,7 @@ internal static class ChekiHiResSidecar
 /// </para>
 ///
 /// <para>
-/// <see cref="Plugin.ConfigChekiHighResEnabled"/> が false のときは元処理をそのまま走らせる
+/// <see cref="Configs.ChekiHighResEnabled"/> が false のときは元処理をそのまま走らせる
 /// （Prefix が true を返す → vanilla が実行される）。
 /// </para>
 /// </summary>
@@ -142,7 +142,7 @@ public static class ChekiResolutionPatch
 
     private static bool Prefix(Saves __instance, ref IEnumerator __result)
     {
-        if (!Plugin.ConfigChekiHighResEnabled.Value)
+        if (!Configs.ChekiHighResEnabled.Value)
         {
             // 既定 OFF: vanilla 挙動。ホルダーは空に戻しておく（古い hi-res が残っていると誤使用の元）。
             ChekiHiResSidecar.DestroyIfAny();
@@ -154,7 +154,7 @@ public static class ChekiResolutionPatch
 
     private static IEnumerator CaptureDualRes(Saves self)
     {
-        int hiSize = Mathf.Clamp(Plugin.ConfigChekiSize.Value, SizeLowerClamp, SizeUpperClamp);
+        int hiSize = Mathf.Clamp(Configs.ChekiSize.Value, SizeLowerClamp, SizeUpperClamp);
 
         if (!s_loggedApplied)
         {

--- a/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiSaveHiResPatch.cs
@@ -67,7 +67,7 @@ public static class ChekiSaveHiResPatch
 
     private static void Postfix(GameData __instance, int slot)
     {
-        if (!Plugin.ConfigChekiHighResEnabled.Value)
+        if (!Configs.ChekiHighResEnabled.Value)
         {
             // Config OFF: sidecar は使わない。残留があれば破棄。
             ChekiHiResSidecar.DestroyIfAny();
@@ -108,7 +108,7 @@ public static class ChekiSaveHiResPatch
 
             string key = KeyFor(slot);
             ExSaveStore.CurrentSession.Set(key, payload);
-            PatchLogger.LogInfo($"[ChekiSaveHiResPatch] ExSave に格納: {key} ({size}x{size}, {Plugin.ConfigChekiFormat.Value}, {payload.Length} bytes)");
+            PatchLogger.LogInfo($"[ChekiSaveHiResPatch] ExSave に格納: {key} ({size}x{size}, {Configs.ChekiFormat.Value}, {payload.Length} bytes)");
         }
         catch (Exception ex)
         {
@@ -122,7 +122,7 @@ public static class ChekiSaveHiResPatch
     }
 
     /// <summary>
-    /// 設定された <see cref="Plugin.ConfigChekiFormat"/> に応じて Texture2D をバイト列にエンコードする。
+    /// 設定された <see cref="Configs.ChekiFormat"/> に応じて Texture2D をバイト列にエンコードする。
     ///
     /// <para>
     /// 形式:
@@ -135,7 +135,7 @@ public static class ChekiSaveHiResPatch
     /// </summary>
     private static byte[] EncodePayload(Texture2D tex)
     {
-        var format = Plugin.ConfigChekiFormat.Value;
+        var format = Configs.ChekiFormat.Value;
         try
         {
             switch (format)
@@ -143,7 +143,7 @@ public static class ChekiSaveHiResPatch
                 case ChekiImageFormat.JPG:
                     // ConfigChekiJpgQuality は YAML range [1,100] により BepInEx が起動時に
                     // AcceptableValueRange でクランプ済みのため、ここで Mathf.Clamp は不要。
-                    return ImageConversion.EncodeToJPG(tex, Plugin.ConfigChekiJpgQuality.Value);
+                    return ImageConversion.EncodeToJPG(tex, Configs.ChekiJpgQuality.Value);
 
                 case ChekiImageFormat.PNG:
                 default:

--- a/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChromaticAberrationPatch.cs
@@ -18,7 +18,7 @@ public static class ChromaticAberrationPatch
 
     private static bool Prefix(ChromaticAberration __instance, ref bool __result)
     {
-        if (!Plugin.ConfigDisableChromaticAberration.Value)
+        if (!Configs.DisableChromaticAberration.Value)
             return true;
         __result = false;
         return false;

--- a/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ContinueVoiceOnTapPatch.cs
@@ -50,7 +50,7 @@ public static class ContinueVoiceOnTap_UpdateRoutinePatch
     private static void Prefix(out bool __state)
     {
         __state = false;
-        if (!Plugin.ConfigContinueVoiceOnTap.Value) return;
+        if (!Configs.ContinueVoiceOnTap.Value) return;
         ContinueVoiceState.SuppressDepth++;
         __state = true;
     }
@@ -75,7 +75,7 @@ public static class ContinueVoiceOnTap_ToNextTextPatch
     private static void Prefix(out bool __state)
     {
         __state = false;
-        if (!Plugin.ConfigContinueVoiceOnTap.Value) return;
+        if (!Configs.ContinueVoiceOnTap.Value) return;
         ContinueVoiceState.SuppressDepth++;
         __state = true;
     }
@@ -99,7 +99,7 @@ public static class ContinueVoiceOnTap_StopVoicePatch
 
     private static bool Prefix()
     {
-        if (!Plugin.ConfigContinueVoiceOnTap.Value) return true; // 設定オフ時は早期リターン
+        if (!Configs.ContinueVoiceOnTap.Value) return true; // 設定オフ時は早期リターン
         return ContinueVoiceState.SuppressDepth <= 0; // 抑制中なら StopVoice を実行しない
     }
 }
@@ -115,7 +115,7 @@ public static class ContinueVoiceOnTap_FinishLipSyncPatch
 
     private static bool Prefix()
     {
-        if (!Plugin.ConfigContinueVoiceOnTap.Value) return true; // 設定オフ時は早期リターン
+        if (!Configs.ContinueVoiceOnTap.Value) return true; // 設定オフ時は早期リターン
         return ContinueVoiceState.SuppressDepth <= 0; // 抑制中なら FinishLipSync を実行しない（LipSyncCalculator が音声終了時に自動停止）
     }
 }

--- a/BunnyGarden2FixMod/Patches/ConversationChoiceCheatPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ConversationChoiceCheatPatch.cs
@@ -59,7 +59,7 @@ public static class ConversationChoiceCheatPatch
 
     private static void Postfix(ConversationChoice __instance)
     {
-        if (!Plugin.ConfigCheatLikability.Value) return;
+        if (!Configs.CheatLikability.Value) return;
         try
         {
             var shuffleTable = s_shuffleTableField.GetValue(__instance) as List<int>;

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/CostumeChangerPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/CostumeChangerPatch.cs
@@ -46,7 +46,7 @@ public static class CostumeChangerPatch
     /// </summary>
     public static void Initialize(GameObject parent)
     {
-        if (!Plugin.ConfigCostumeChangerEnabled.Value) return;
+        if (!Configs.CostumeChangerEnabled.Value) return;
         // FittingRoom リフレクションキャッシュを起動時に一括取得。
         s_fittingRoomLoadingField = AccessTools.Field(typeof(FittingRoom), "m_loading");
         s_fittingRoomCharIDField = AccessTools.Field(typeof(FittingRoom), "m_charID");
@@ -70,7 +70,7 @@ public static class CostumeChangerPatch
     {
         // PatchLogger.LogInfo は内部で null-conditional ガード済みのため、
         // Initialize 未了でも安全に呼べる（最悪ログがドロップするだけ）。
-        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
         PatchLogger.LogInfo($"[CostumeChangerPatch] 適用 (enabled={enabled})");
         return enabled;
     }
@@ -90,7 +90,7 @@ public static class CostumeChangerPatch
         if (IsFittingRoomActive()) return;
 
         // RespectGameCostumeOverride: 本体が ForceXxx を設定中なら MOD override を一時停止
-        if ((Plugin.ConfigRespectGameCostumeOverride?.Value ?? true)
+        if ((Configs.RespectGameCostumeOverride?.Value ?? true)
             && GBSystem.Instance != null
             && GBSystem.Instance.GetCostumeOverride() != GBSystem.CostumeOverride.None)
         {
@@ -225,7 +225,7 @@ public static class CostumeChangerPatch
 [HarmonyPatch(typeof(FittingRoom), "setupGenreSelect")]
 internal static class FittingRoomOnEnterPatch
 {
-    private static bool Prepare() => Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+    private static bool Prepare() => Configs.CostumeChangerEnabled?.Value ?? true;
 
     private static void Prefix(FittingRoom __instance)
     {

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/KneeSocksLoader.cs
@@ -377,7 +377,7 @@ internal static class KneeSocksSetupPatch
 {
     private static bool Prepare()
     {
-        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
         if (enabled) PatchLogger.LogInfo("[KneeSocksSetupPatch] 適用");
         return enabled;
     }
@@ -393,7 +393,7 @@ internal static class KneeSocksSetupPantiesOnlyPatch
 {
     private static bool Prepare()
     {
-        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
         if (enabled) PatchLogger.LogInfo("[KneeSocksSetupPantiesOnlyPatch] 適用");
         return enabled;
     }
@@ -411,7 +411,7 @@ internal static class KneeSocksApplyStockingPatch
 {
     private static bool Prepare()
     {
-        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
         if (enabled) PatchLogger.LogInfo("[KneeSocksApplyStockingPatch] 適用");
         return enabled;
     }

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/PantiesAltSlotMatchPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/PantiesAltSlotMatchPatch.cs
@@ -81,7 +81,7 @@ public static class PantiesAltSlotMatchPatch
 
     static void Postfix(CharacterHandle __instance, Material[] mat, ref int __result)
     {
-        if (!Plugin.ConfigPantiesAltSlotMatch.Value) return;
+        if (!Configs.PantiesAltSlotMatch.Value) return;
 
         bool hasId = TryGetCharID(__instance, out var charId);
         bool hasCostume = TryGetCostume(__instance, out var costume);
@@ -111,7 +111,7 @@ public static class PantiesAltSlotMatchPatch
         // Postfix の例外漏れは ReloadPanties を巻き込んで装備不適用 (可視的失敗) になるため握りつぶす。
         try
         {
-            if (Plugin.ConfigPantiesAltSlotOverrideOnly.Value)
+            if (Configs.PantiesAltSlotOverrideOnly.Value)
             {
                 if (!hasId) return;
                 if (!PantiesOverrideStore.TryGet(charId, out _, out _)) return;

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/SwimWearStockingPatch.cs
@@ -64,7 +64,7 @@ public static class SwimWearStockingPatch
 
     static bool Prepare()
     {
-        bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+        bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
         if (enabled) PatchLogger.LogInfo("[SwimWearStockingPatch] 適用");
         return enabled;
     }
@@ -139,7 +139,7 @@ public static class SwimWearStockingPatch
                            && overrideType != 0;
         bool isKneeSocks = hasOverride && StockingOverrideStore.IsKneeSocksType(overrideType);
 
-        if (Plugin.ConfigDisableStockings.Value) { hasOverride = false; isKneeSocks = false; }
+        if (Configs.DisableStockings.Value) { hasOverride = false; isKneeSocks = false; }
 
         if (!hasOverride)
         {
@@ -290,9 +290,9 @@ public static class SwimWearStockingPatch
         // ニーハイは形状・カバー範囲が異なり本補正の前提（尻まわりの z-fighting）と合わないため対象外
         if (isKneeSocks) return;
 
-        float minOffset = Plugin.ConfigStockingOffset?.Value ?? 0f;
-        float skinPushAmount = Plugin.ConfigStockingSkinShrink?.Value ?? 0f;
-        float falloffRadius = Plugin.ConfigStockingSkinFalloffRadius?.Value ?? 0f;
+        float minOffset = Configs.StockingOffset?.Value ?? 0f;
+        float skinPushAmount = Configs.StockingSkinShrink?.Value ?? 0f;
+        float falloffRadius = Configs.StockingSkinFalloffRadius?.Value ?? 0f;
         if (minOffset <= 0f && skinPushAmount <= 0f) return;
 
         var currentDonor = stockingsSmr.sharedMesh;
@@ -353,7 +353,7 @@ public static class SwimWearStockingPatch
         float shapeFalloffRadius = 0f;
         if (!isKneeSocks)
         {
-            shapeFalloffRadius = Plugin.ConfigStockingShapeFalloffRadius?.Value ?? 0f;
+            shapeFalloffRadius = Configs.StockingShapeFalloffRadius?.Value ?? 0f;
             if (shapeFalloffRadius > 0f) shapeAnchorVerts = CollectShrinkAnchorVerts(renderers);
         }
 

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
@@ -72,7 +72,7 @@ public class CostumePickerController : MonoBehaviour
     /// <summary>ゲーム側入力（GBInput）をパッチで抑制すべき状態かを返す。</summary>
     public static bool ShouldSuppressGameInput()
     {
-        if (Plugin.ConfigCostumeChangerEnabled?.Value != true) return false;
+        if (Configs.CostumeChangerEnabled?.Value != true) return false;
         // ConfirmDialog 表示中は抑制解除（ダイアログが GBInput を読むため）
         if (ConfirmDialogHelper.IsActive()) return false;
         var ctrl = Instance;
@@ -109,10 +109,10 @@ public class CostumePickerController : MonoBehaviour
 
         // F9 設定パネル等から Stocking 系 Config が変更された場合、picker open 中なら即時メッシュ反映する。
         // ShapeFalloff は blendShape 全 frame の再構築を伴って重いので Update() でデバウンスする。
-        if (Plugin.ConfigStockingOffset != null) Plugin.ConfigStockingOffset.SettingChanged += OnStockingTuneChanged;
-        if (Plugin.ConfigStockingSkinShrink != null) Plugin.ConfigStockingSkinShrink.SettingChanged += OnStockingTuneChanged;
-        if (Plugin.ConfigStockingSkinFalloffRadius != null) Plugin.ConfigStockingSkinFalloffRadius.SettingChanged += OnStockingTuneChanged;
-        if (Plugin.ConfigStockingShapeFalloffRadius != null) Plugin.ConfigStockingShapeFalloffRadius.SettingChanged += OnStockingShapeFalloffChanged;
+        if (Configs.StockingOffset != null) Configs.StockingOffset.SettingChanged += OnStockingTuneChanged;
+        if (Configs.StockingSkinShrink != null) Configs.StockingSkinShrink.SettingChanged += OnStockingTuneChanged;
+        if (Configs.StockingSkinFalloffRadius != null) Configs.StockingSkinFalloffRadius.SettingChanged += OnStockingTuneChanged;
+        if (Configs.StockingShapeFalloffRadius != null) Configs.StockingShapeFalloffRadius.SettingChanged += OnStockingShapeFalloffChanged;
     }
 
     private void OnDestroy()
@@ -128,10 +128,10 @@ public class CostumePickerController : MonoBehaviour
             m_view.OnResetAllClicked -= HandleResetAllClicked;
             m_view.OnUnlockAllClicked -= HandleUnlockAllClicked;
         }
-        if (Plugin.ConfigStockingOffset != null) Plugin.ConfigStockingOffset.SettingChanged -= OnStockingTuneChanged;
-        if (Plugin.ConfigStockingSkinShrink != null) Plugin.ConfigStockingSkinShrink.SettingChanged -= OnStockingTuneChanged;
-        if (Plugin.ConfigStockingSkinFalloffRadius != null) Plugin.ConfigStockingSkinFalloffRadius.SettingChanged -= OnStockingTuneChanged;
-        if (Plugin.ConfigStockingShapeFalloffRadius != null) Plugin.ConfigStockingShapeFalloffRadius.SettingChanged -= OnStockingShapeFalloffChanged;
+        if (Configs.StockingOffset != null) Configs.StockingOffset.SettingChanged -= OnStockingTuneChanged;
+        if (Configs.StockingSkinShrink != null) Configs.StockingSkinShrink.SettingChanged -= OnStockingTuneChanged;
+        if (Configs.StockingSkinFalloffRadius != null) Configs.StockingSkinFalloffRadius.SettingChanged -= OnStockingTuneChanged;
+        if (Configs.StockingShapeFalloffRadius != null) Configs.StockingShapeFalloffRadius.SettingChanged -= OnStockingShapeFalloffChanged;
         if (Instance == this) Instance = null;
     }
 
@@ -198,8 +198,8 @@ public class CostumePickerController : MonoBehaviour
             ReapplyStockingForTune();
         }
 
-        if (Plugin.ConfigCostumeChangerEnabled == null) return;
-        if (!Plugin.ConfigCostumeChangerEnabled.Value) return;
+        if (Configs.CostumeChangerEnabled == null) return;
+        if (!Configs.CostumeChangerEnabled.Value) return;
         // Awake で AddComponent<CostumePickerView>() が何らかの理由（例外）で失敗したケース防御。
         // m_view.IsShown などを触る前段で早期 return する。
         if (m_view == null) return;
@@ -212,7 +212,7 @@ public class CostumePickerController : MonoBehaviour
         if (kb == null) return;
 
         // トグル
-        if (Plugin.ConfigCostumeChangerShow.IsTriggered())
+        if (Configs.CostumeChangerShow.IsTriggered())
         {
             if (m_view.IsShown)
             {

--- a/BunnyGarden2FixMod/Patches/CostumeChanger/WardrobeLivePatches.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/WardrobeLivePatches.cs
@@ -29,7 +29,7 @@ internal static class WardrobeLivePatches
     {
         private static bool Prepare()
         {
-            bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+            bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
             if (enabled) PatchLogger.LogInfo("[WardrobeLivePatches.ReloadPanties] 適用");
             return enabled;
         }
@@ -52,7 +52,7 @@ internal static class WardrobeLivePatches
     {
         private static bool Prepare()
         {
-            bool enabled = Plugin.ConfigCostumeChangerEnabled?.Value ?? true;
+            bool enabled = Configs.CostumeChangerEnabled?.Value ?? true;
             if (enabled) PatchLogger.LogInfo("[WardrobeLivePatches.ApplyStocking] 適用");
             return enabled;
         }

--- a/BunnyGarden2FixMod/Patches/DepthOfFieldPatch.cs
+++ b/BunnyGarden2FixMod/Patches/DepthOfFieldPatch.cs
@@ -18,7 +18,7 @@ public static class DepthOfFieldPatch
 
     private static bool Prefix(DepthOfField __instance, ref bool __result)
     {
-        if (!Plugin.ConfigDisableDepthOfField.Value)
+        if (!Configs.DisableDepthOfField.Value)
             return true;
         __result = false;
         return false;

--- a/BunnyGarden2FixMod/Patches/DisableStockingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/DisableStockingPatch.cs
@@ -30,7 +30,7 @@ public static class DisableStockingPatch
     private static void Prefix(ref int __0)
     {
         if (KneeSocksLoader.IsPreloading) return; // マテリアルプリロード中はスキップ
-        if (!Plugin.ConfigDisableStockings.Value) return;
+        if (!Configs.DisableStockings.Value) return;
         __0 = 0;
     }
 }

--- a/BunnyGarden2FixMod/Patches/DisplaySettingsPatch.cs
+++ b/BunnyGarden2FixMod/Patches/DisplaySettingsPatch.cs
@@ -11,15 +11,15 @@ namespace BunnyGarden2FixMod.Patches;
 ///
 /// <para>
 /// <b>VSync</b><br/>
-/// <see cref="Plugin.ConfigForceVSync"/> が true のとき、
+/// <see cref="Configs.ForceVSync"/> が true のとき、
 /// <see cref="QualitySettings.vSyncCount"/> を 1 に固定します。
 /// VSync が有効な間はフレームレートがモニターのリフレッシュレートに同期され、
-/// <see cref="Plugin.ConfigFrameRate"/> の設定より優先されます。
+/// <see cref="Configs.FrameRate"/> の設定より優先されます。
 /// </para>
 ///
 /// <para>
 /// <b>排他的フルスクリーン</b><br/>
-/// <see cref="Plugin.ConfigForceExclusiveFullScreen"/> が true のとき、
+/// <see cref="Configs.ForceExclusiveFullScreen"/> が true のとき、
 /// ゲームがフルスクリーンモードに切り替える都度
 /// <see cref="Screen.fullScreenMode"/> を
 /// <see cref="FullScreenMode.ExclusiveFullScreen"/> に強制します。<br/>
@@ -36,11 +36,11 @@ namespace BunnyGarden2FixMod.Patches;
 public class VSyncPatch
 {
     private static void Postfix()
-        => LiveConfigBinding.BindAndApply(Plugin.ConfigForceVSync, Apply);
+        => LiveConfigBinding.BindAndApply(Configs.ForceVSync, Apply);
 
     private static void Apply()
     {
-        if (Plugin.ConfigForceVSync.Value)
+        if (Configs.ForceVSync.Value)
         {
             QualitySettings.vSyncCount = 1;
             PatchLogger.LogInfo("[DisplaySettings] VSync 強制 ON を適用しました (vSyncCount=1)");
@@ -61,7 +61,7 @@ public class ForceExclusiveFullScreenPatch
 {
     private static void Postfix()
     {
-        if (!Plugin.ConfigForceExclusiveFullScreen.Value) return;
+        if (!Configs.ForceExclusiveFullScreen.Value) return;
         if (!Screen.fullScreen) return;
 
         // 既に ExclusiveFullScreen なら再設定しない（GBSystem.Update のループ防止）

--- a/BunnyGarden2FixMod/Patches/EndingChekiSlideshowPatch.cs
+++ b/BunnyGarden2FixMod/Patches/EndingChekiSlideshowPatch.cs
@@ -31,7 +31,7 @@ public static class EndingChekiSlideshowPatch
 
     private static void Postfix(StaffCreditScene __instance)
     {
-        if (!Plugin.ConfigEndingChekiSlideshow.Value) return;
+        if (!Configs.EndingChekiSlideshow.Value) return;
         __instance.gameObject.AddComponent<ChekiSlideshowBehaviour>();
     }
 }
@@ -167,7 +167,7 @@ public sealed class ChekiSlideshowBehaviour : MonoBehaviour
                 // 写真テクスチャ → Sprite。ExSave に hi-res があればそちらを優先し、
                 // 失敗・未設定時は vanilla 320 の raw データから構築する。
                 Texture2D tex = null;
-                if (Plugin.ConfigChekiHighResEnabled.Value)
+                if (Configs.ChekiHighResEnabled.Value)
                 {
                     string key = ChekiSaveHiResPatch.KeyFor(slot);
                     if (ExSaveStore.CurrentSession.TryGet(key, out byte[] payload)

--- a/BunnyGarden2FixMod/Patches/ExSaveLifecyclePatch.cs
+++ b/BunnyGarden2FixMod/Patches/ExSaveLifecyclePatch.cs
@@ -42,7 +42,7 @@ namespace BunnyGarden2FixMod.Patches;
 /// </list>
 ///
 /// <para>
-/// 本パッチは <see cref="Plugin.ConfigChekiHighResEnabled"/> の値に関係なく常に適用される
+/// 本パッチは <see cref="Configs.ChekiHighResEnabled"/> の値に関係なく常に適用される
 /// （ExSave 基盤は汎用であり、将来の機能追加でも使える共通配線）。
 /// </para>
 /// </summary>

--- a/BunnyGarden2FixMod/Patches/ExtraResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ExtraResolutionPatch.cs
@@ -21,7 +21,7 @@ namespace BunnyGarden2FixMod.Patches;
 ///
 /// <list type="number">
 /// <item>バニラ <see cref="SaveData.m_displaySize"/> には常に <c>0/1/2</c> のどれかを書く（バニラ互換）</item>
-/// <item>「拡張が選ばれているか」の真偽は <c>Plugin.ConfigExtraActive</c>（BepInEx config）に書く</item>
+/// <item>「拡張が選ばれているか」の真偽は <c>Configs.ExtraActive</c>（BepInEx config）に書く</item>
 /// </list>
 ///
 /// 拡張選択時はバニラ側には <c>DisplaySize=0</c>（=1080P と同値）を書き、
@@ -70,7 +70,7 @@ public static class ExtraResolutionPatch
         if (list.Count != VanillaLabelCount) return;
 
         list.Insert(ExtraUiIndex, ExtraLabelPlaceholder);
-        sel = Plugin.ConfigExtraActive.Value
+        sel = Configs.ExtraActive.Value
             ? ExtraUiIndex
             : sel + 1;
     }
@@ -85,7 +85,7 @@ public static class ExtraResolutionPatch
         if (__instance.m_select != ExtraUiIndex) return;
         if (__instance.m_text == null) return;
 
-        var (w, h) = NormalizeAspect(Plugin.ConfigExtraWidth.Value, Plugin.ConfigExtraHeight.Value);
+        var (w, h) = NormalizeAspect(Configs.ExtraWidth.Value, Configs.ExtraHeight.Value);
         __instance.m_text.SetWithoutMSGID($"{w}×{h}");
     }
 
@@ -103,8 +103,8 @@ public static class ExtraResolutionPatch
 
         int uiSelect = __result;
         bool isExtra = uiSelect == ExtraUiIndex;
-        if (Plugin.ConfigExtraActive.Value != isExtra)
-            Plugin.ConfigExtraActive.Value = isExtra;
+        if (Configs.ExtraActive.Value != isExtra)
+            Configs.ExtraActive.Value = isExtra;
 
         __result = isExtra ? 0 : uiSelect - 1;
     }
@@ -115,21 +115,21 @@ public static class ExtraResolutionPatch
     {
         if ((int)size != 0)
         {
-            if (Plugin.ConfigExtraActive.Value)
-                Plugin.ConfigExtraActive.Value = false;
+            if (Configs.ExtraActive.Value)
+                Configs.ExtraActive.Value = false;
             return true;
         }
 
-        if (!Plugin.ConfigExtraActive.Value)
+        if (!Configs.ExtraActive.Value)
             return true;
 
-        int rawW = Plugin.ConfigExtraWidth.Value;
-        int rawH = Plugin.ConfigExtraHeight.Value;
+        int rawW = Configs.ExtraWidth.Value;
+        int rawH = Configs.ExtraHeight.Value;
         if (rawW <= 0 || rawH <= 0)
         {
             PatchLogger.LogWarning(
                 $"ExtraWidth/ExtraHeight が不正です ({rawW}x{rawH})。1080P にフォールバックします。");
-            Plugin.ConfigExtraActive.Value = false;
+            Configs.ExtraActive.Value = false;
             return true;
         }
 

--- a/BunnyGarden2FixMod/Patches/FixAnimationClippingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/FixAnimationClippingPatch.cs
@@ -73,7 +73,7 @@ public static class FixAnimationClippingPatch
 
     private static void Postfix(CharacterHandle __instance, MOTION __0, float __1)
     {
-        if (!Plugin.ConfigFixAnimationClipping.Value || __instance.m_chara == null)
+        if (!Configs.FixAnimationClipping.Value || __instance.m_chara == null)
             return;
 
         var fixer = __instance.m_chara.GetOrAddComponent<Fixer>();

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraController.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraController.cs
@@ -33,7 +33,7 @@ public class FreeCameraController : MonoBehaviour
         if (useMouseView && Mouse.current != null)
         {
             Vector2 mouseDelta = Mouse.current.delta.ReadValue();
-            float sensitivity = Plugin.ConfigSensitivity.Value;
+            float sensitivity = Configs.Sensitivity.Value;
             rotationH += mouseDelta.x * sensitivity * deltaTime;
             rotationV -= mouseDelta.y * sensitivity * deltaTime;
         }
@@ -41,7 +41,7 @@ public class FreeCameraController : MonoBehaviour
         Vector2 rightStick = GamepadHelper.ReadRightStick();
         if (rightStick.sqrMagnitude > StickDeadzoneSqr)
         {
-            float sensitivity = Plugin.ConfigSensitivity.Value * ControllerLookScale;
+            float sensitivity = Configs.Sensitivity.Value * ControllerLookScale;
             rotationH += rightStick.x * sensitivity * deltaTime;
             rotationV -= rightStick.y * sensitivity * deltaTime;
         }
@@ -50,21 +50,21 @@ public class FreeCameraController : MonoBehaviour
         transform.rotation = Quaternion.AngleAxis(rotationH, Vector3.up);
         transform.rotation *= Quaternion.AngleAxis(rotationV, Vector3.right);
 
-        float speed = Plugin.ConfigSpeed.Value;
-        if (Plugin.ConfigControllerEnabled.Value)
+        float speed = Configs.Speed.Value;
+        if (Configs.ControllerEnabled.Value)
         {
             if (GamepadHelper.IsButtonHeld(ControllerButton.R))
-                speed = Plugin.ConfigFastSpeed.Value;
+                speed = Configs.FastSpeed.Value;
             else if (GamepadHelper.IsButtonHeld(ControllerButton.L))
-                speed = Plugin.ConfigSlowSpeed.Value;
+                speed = Configs.SlowSpeed.Value;
         }
 
         if (Keyboard.current != null)
         {
             if (Keyboard.current.leftShiftKey.isPressed || Keyboard.current.rightShiftKey.isPressed)
-                speed = Plugin.ConfigFastSpeed.Value;
+                speed = Configs.FastSpeed.Value;
             else if (Keyboard.current.leftCtrlKey.isPressed || Keyboard.current.rightCtrlKey.isPressed)
-                speed = Plugin.ConfigSlowSpeed.Value;
+                speed = Configs.SlowSpeed.Value;
 
             if (Keyboard.current.wKey.isPressed || Keyboard.current.upArrowKey.isPressed)
                 transform.position += speed * deltaTime * transform.forward;
@@ -80,7 +80,7 @@ public class FreeCameraController : MonoBehaviour
                 transform.position += speed * deltaTime * -transform.up;
         }
 
-        if (Plugin.ConfigControllerEnabled.Value)
+        if (Configs.ControllerEnabled.Value)
         {
             Vector2 leftStick = GamepadHelper.ReadLeftStick();
             if (leftStick.sqrMagnitude > StickDeadzoneSqr)

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -35,10 +35,10 @@ public class FreeCameraManager : MonoBehaviour
 
     private void Update()
     {
-        if (Plugin.ConfigFreeCamToggle.IsTriggered())
+        if (Configs.FreeCamToggle.IsTriggered())
             ToggleFreeCam();
 
-        if (Plugin.ConfigFixedFreeCamToggle.IsTriggered())
+        if (Configs.FixedFreeCamToggle.IsTriggered())
             ToggleFixedFreeCam();
     }
 
@@ -179,7 +179,7 @@ public class FreeCameraManager : MonoBehaviour
             eventSystem.SetSelectedGameObject(null);
         }
 
-        if (!Plugin.ConfigHideGameUiInFreeCam.Value)
+        if (!Configs.HideGameUiInFreeCam.Value)
             return;
 
         foreach (var canvas in canvases)
@@ -227,9 +227,9 @@ public class FreeCameraManager : MonoBehaviour
         GUILayout.Label(
             "Move: Arrow/WASD or Left Stick, Up/Down: E/Q or ZR/ZL, Look: Mouse or Right Stick, Speed: Shift/Ctrl or R/L");
         GUI.color = Color.green;
-        GUILayout.Label($"Free Camera: ON ({Plugin.ConfigFreeCamToggle}=OFF)");
+        GUILayout.Label($"Free Camera: ON ({Configs.FreeCamToggle}=OFF)");
         GUI.color = Color.yellow;
-        GUILayout.Label($"Fixed Mode: {(IsFixed ? "ON" : "OFF")} ({Plugin.ConfigFixedFreeCamToggle}=TOGGLE)");
+        GUILayout.Label($"Fixed Mode: {(IsFixed ? "ON" : "OFF")} ({Configs.FixedFreeCamToggle}=TOGGLE)");
         GUI.color = Color.white;
     }
 }

--- a/BunnyGarden2FixMod/Patches/GambleAlwaysWinPatch.cs
+++ b/BunnyGarden2FixMod/Patches/GambleAlwaysWinPatch.cs
@@ -128,7 +128,7 @@ public static class GambleAlwaysWinPatch
     /// </summary>
     public static int RerollIfNeeded(int winAmount)
     {
-        if (!Plugin.ConfigGambleAlwaysWinEnabled.Value) return winAmount;
+        if (!Configs.GambleAlwaysWinEnabled.Value) return winAmount;
         if (winAmount >= 0) return winAmount;
 
         var gamble = Object.FindFirstObjectByType<Gamble>();

--- a/BunnyGarden2FixMod/Patches/GameplayFullscreenUltrawideSupport.cs
+++ b/BunnyGarden2FixMod/Patches/GameplayFullscreenUltrawideSupport.cs
@@ -25,7 +25,7 @@ internal static class GameplayFullscreenUltrawideSupport
 
     internal static bool ShouldUseNativeFullscreen()
     {
-        if (!Plugin.ConfigFullscreenUltrawideEnabled.Value || !Screen.fullScreen)
+        if (!Configs.FullscreenUltrawideEnabled.Value || !Screen.fullScreen)
         {
             return false;
         }
@@ -64,8 +64,8 @@ internal static class GameplayFullscreenUltrawideSupport
 
     internal static (int width, int height) GetTargetResolution()
     {
-        int configW = Plugin.ConfigWidth.Value;
-        int configH = Plugin.ConfigHeight.Value;
+        int configW = Configs.Width.Value;
+        int configH = Configs.Height.Value;
         if (IsWiderThan16x9(configW, configH))
         {
             return (configW, configH);
@@ -146,7 +146,7 @@ internal static class GameplayFullscreenUltrawideSupport
         (int targetW, int targetH) = GetTargetResolution();
         string state = $"{reason} scenes={GetSceneList()} ingame={system.IsIngame} inBar={IsGameDataInBar(system)} " +
             $"screen={Screen.width}x{Screen.height} fullscreen={Screen.fullScreen} current={Screen.currentResolution.width}x{Screen.currentResolution.height} " +
-            $"target={targetW}x{targetH} enabled={Plugin.ConfigFullscreenUltrawideEnabled.Value} use={ShouldUseNativeFullscreen()}";
+            $"target={targetW}x{targetH} enabled={Configs.FullscreenUltrawideEnabled.Value} use={ShouldUseNativeFullscreen()}";
 
         if (state == lastStateLog && Time.unscaledTime < nextStateLogTime)
         {
@@ -161,7 +161,7 @@ internal static class GameplayFullscreenUltrawideSupport
     internal static void ApplyUiAspect()
     {
         //ShouldUseNativeFullScreenの判定はコストが高いので、ConfigFullscreenUltrawideEnabledの判定を先に行う
-        if (!Plugin.ConfigFullscreenUltrawideEnabled.Value) return;
+        if (!Configs.FullscreenUltrawideEnabled.Value) return;
         if (!ShouldUseNativeFullscreen())
         {
             ResetUiAspect();

--- a/BunnyGarden2FixMod/Patches/PurchasableItemCheatPatch.cs
+++ b/BunnyGarden2FixMod/Patches/PurchasableItemCheatPatch.cs
@@ -39,7 +39,7 @@ public static class PurchasableItemCheatPatch
 
     private static void Postfix(PurchasableItem __instance, PurchasableParam purchasableParam)
     {
-        if (!Plugin.ConfigCheatLikability.Value) return;
+        if (!Configs.CheatLikability.Value) return;
         try
         {
             if (GBSystem.Instance == null) return;

--- a/BunnyGarden2FixMod/Patches/SetRefreshRatePatch.cs
+++ b/BunnyGarden2FixMod/Patches/SetRefreshRatePatch.cs
@@ -14,11 +14,11 @@ namespace BunnyGarden2FixMod.Patches;
 public class SetRefreshRatePatch
 {
     private static void Postfix()
-        => LiveConfigBinding.BindAndApply(Plugin.ConfigFrameRate, Apply);
+        => LiveConfigBinding.BindAndApply(Configs.FrameRate, Apply);
 
     private static void Apply()
     {
-        if (Plugin.ConfigFrameRate.Value <= 0)
+        if (Configs.FrameRate.Value <= 0)
         {
             // 0 以下なら上限撤廃
             Application.targetFrameRate = -1;
@@ -26,7 +26,7 @@ public class SetRefreshRatePatch
             return;
         }
         // 指定したフレームレートに設定
-        Application.targetFrameRate = Plugin.ConfigFrameRate.Value;
-        PatchLogger.LogInfo($"フレームレートを {Plugin.ConfigFrameRate.Value} FPS に設定しました");
+        Application.targetFrameRate = Configs.FrameRate.Value;
+        PatchLogger.LogInfo($"フレームレートを {Configs.FrameRate.Value} FPS に設定しました");
     }
 }

--- a/BunnyGarden2FixMod/Patches/SteelFrameUltimateSurvivorPatch.cs
+++ b/BunnyGarden2FixMod/Patches/SteelFrameUltimateSurvivorPatch.cs
@@ -24,7 +24,7 @@ public static class SteelFrameUltimateSurvivorPatch
 
     private static void Postfix(SteelFrame __instance)
     {
-        if (!Plugin.ConfigUltimateSurvivorEnabled.Value) return;
+        if (!Configs.UltimateSurvivorEnabled.Value) return;
         if (__instance.m_state != SteelFrame.State.InGame) return;
 
         // 落下タイマーを毎フレームリセット → DropOutTime を超えなくなる

--- a/BunnyGarden2FixMod/Patches/TalkReactionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/TalkReactionPatch.cs
@@ -45,7 +45,7 @@ public static class TalkReactionPatch
 
     private static bool Prefix(CharacterHandle __instance)
     {
-        if (!Plugin.ConfigMoreTalkReactions.Value)
+        if (!Configs.MoreTalkReactions.Value)
             return true;
 
         // まずは本来のメソッドの条件にマッチさせる

--- a/BunnyGarden2FixMod/Patches/TimeController.cs
+++ b/BunnyGarden2FixMod/Patches/TimeController.cs
@@ -27,12 +27,12 @@ public class TimeController : MonoBehaviour
 
     private void Update()
     {
-        fastForward = Plugin.ConfigFastForward.IsHeld();
+        fastForward = Configs.FastForward.IsHeld();
 
-        if (Plugin.ConfigTimeStopToggle.IsTriggered())
+        if (Configs.TimeStopToggle.IsTriggered())
             stop = !stop;
 
-        if (Plugin.ConfigFrameAdvance.IsTriggered())
+        if (Configs.FrameAdvance.IsTriggered())
         {
             stop = true;
             frames = 1;
@@ -48,7 +48,7 @@ public class TimeController : MonoBehaviour
         else if (stop)
             Time.timeScale = 0f;
         else if (fastForward)
-            Time.timeScale = Plugin.ConfigFastForwardSpeed.Value;
+            Time.timeScale = Configs.FastForwardSpeed.Value;
         else if (wasControlling)
             // MOD の制御から抜けた直後の 1 フレームだけ 1f に戻す。
             // 毎フレーム 1f を書くとゲーム側の ScopedFastForward（ギャンブル演出の
@@ -65,9 +65,9 @@ public class TimeController : MonoBehaviour
             return;
 
         GUI.color = Color.cyan;
-        GUILayout.Label($"Time Stop: ON ({Plugin.ConfigTimeStopToggle}=OFF)");
-        GUILayout.Label($"Frame Advance: ({Plugin.ConfigFrameAdvance})");
-        GUILayout.Label($"Fast Forward: ({Plugin.ConfigFastForward})");
+        GUILayout.Label($"Time Stop: ON ({Configs.TimeStopToggle}=OFF)");
+        GUILayout.Label($"Frame Advance: ({Configs.FrameAdvance})");
+        GUILayout.Label($"Fast Forward: ({Configs.FastForward})");
         GUI.color = Color.white;
     }
 }

--- a/BunnyGarden2FixMod/Plugin.cs
+++ b/BunnyGarden2FixMod/Plugin.cs
@@ -6,7 +6,6 @@ using System;
 using System.IO;
 using System.Linq;
 using BepInEx;
-using BepInEx.Configuration;
 using BepInEx.Logging;
 using BunnyGarden2FixMod.Utils;
 using GB;
@@ -21,95 +20,6 @@ namespace BunnyGarden2FixMod;
 public class Plugin : BaseUnityPlugin
 {
     private static Plugin Instance;
-
-    // ── Config: Configs.yaml → Generated/Configs.g.cs に転送 ──
-
-    // Animation
-    public static ConfigEntry<bool> ConfigMoreTalkReactions   => Configs.MoreTalkReactions;
-    public static ConfigEntry<bool> ConfigFixAnimationClipping => Configs.FixAnimationClipping;
-
-    // Appearance
-    public static ConfigEntry<bool> ConfigDisableStockings => Configs.DisableStockings;
-
-    // Camera
-    public static ConfigEntry<float> ConfigSensitivity => Configs.Sensitivity;
-    public static ConfigEntry<float> ConfigSpeed      => Configs.Speed;
-    public static ConfigEntry<float> ConfigFastSpeed  => Configs.FastSpeed;
-    public static ConfigEntry<float> ConfigSlowSpeed  => Configs.SlowSpeed;
-    public static ConfigEntry<bool>  ConfigHideGameUiInFreeCam => Configs.HideGameUiInFreeCam;
-    public static ConfigEntry<bool>  ConfigControllerEnabled   => Configs.ControllerEnabled;
-    public static HotkeyConfig       ConfigFreeCamToggle       => Configs.FreeCamToggle;
-    public static HotkeyConfig       ConfigFixedFreeCamToggle  => Configs.FixedFreeCamToggle;
-
-    // Cheat
-    public static ConfigEntry<bool> ConfigCastOrder              => Configs.CastOrder;
-    public static ConfigEntry<bool> ConfigGambleAlwaysWinEnabled => Configs.GambleAlwaysWinEnabled;
-    public static ConfigEntry<bool> ConfigCheatLikability        => Configs.CheatLikability;
-    public static ConfigEntry<bool> ConfigUltimateSurvivorEnabled => Configs.UltimateSurvivorEnabled;
-    public static ConfigEntry<bool> ConfigBunnyDrinksEnabled      => Configs.BunnyDrinksEnabled;
-
-    // Cheki
-    public static ConfigEntry<bool>             ConfigChekiHighResEnabled => Configs.ChekiHighResEnabled;
-    public static ConfigEntry<ChekiImageFormat> ConfigChekiFormat         => Configs.ChekiFormat;
-    public static ConfigEntry<int>              ConfigChekiJpgQuality     => Configs.ChekiJpgQuality;
-    public static ConfigEntry<int>              ConfigChekiSize           => Configs.ChekiSize;
-
-    // Conversation
-    public static ConfigEntry<bool> ConfigContinueVoiceOnTap => Configs.ContinueVoiceOnTap;
-
-    // CostumeChanger
-    public static ConfigEntry<bool>  ConfigCostumeChangerEnabled      => Configs.CostumeChangerEnabled;
-    public static HotkeyConfig       ConfigCostumeChangerShow         => Configs.CostumeChangerShow;
-    public static ConfigEntry<bool>  ConfigRespectGameCostumeOverride => Configs.RespectGameCostumeOverride;
-    public static ConfigEntry<bool>  ConfigSwimWearStocking           => Configs.SwimWearStocking;
-    public static ConfigEntry<float> ConfigStockingOffset             => Configs.StockingOffset;
-    public static ConfigEntry<float> ConfigStockingSkinShrink         => Configs.StockingSkinShrink;
-    public static ConfigEntry<float> ConfigStockingSkinFalloffRadius  => Configs.StockingSkinFalloffRadius;
-    public static ConfigEntry<float> ConfigStockingShapeFalloffRadius => Configs.StockingShapeFalloffRadius;
-    public static ConfigEntry<bool>  ConfigPantiesAltSlotMatch        => Configs.PantiesAltSlotMatch;
-    public static ConfigEntry<bool>  ConfigPantiesAltSlotOverrideOnly => Configs.PantiesAltSlotOverrideOnly;
-
-    // Ending
-    public static ConfigEntry<bool> ConfigEndingChekiSlideshow => Configs.EndingChekiSlideshow;
-
-    // General
-    public static HotkeyConfig      ConfigOverlayToggle     => Configs.OverlayToggle;
-    public static HotkeyConfig      ConfigCaptureScreenshot => Configs.CaptureScreenshot;
-    public static ConfigEntry<int>  ConfigScreenshotScale   => Configs.ScreenshotScale;
-    public static ConfigEntry<bool> ConfigSteamLaunchCheck  => Configs.SteamLaunchCheck;
-
-    // Graphics
-    public static ConfigEntry<int>              ConfigWidth                      => Configs.Width;
-    public static ConfigEntry<int>              ConfigHeight                     => Configs.Height;
-    public static ConfigEntry<int>              ConfigExtraWidth                 => Configs.ExtraWidth;
-    public static ConfigEntry<int>              ConfigExtraHeight                => Configs.ExtraHeight;
-    public static ConfigEntry<int>              ConfigFrameRate                  => Configs.FrameRate;
-    public static ConfigEntry<bool>             ConfigForceVSync                 => Configs.ForceVSync;
-    public static ConfigEntry<bool>             ConfigForceExclusiveFullScreen   => Configs.ForceExclusiveFullScreen;
-    public static ConfigEntry<AntiAliasingType> ConfigAntiAliasing               => Configs.AntiAliasing;
-    public static ConfigEntry<bool>             ConfigDisableChromaticAberration => Configs.DisableChromaticAberration;
-    public static ConfigEntry<bool>             ConfigDisableDepthOfField        => Configs.DisableDepthOfField;
-
-    // Resolution
-    public static ConfigEntry<bool> ConfigFullscreenUltrawideEnabled => Configs.FullscreenUltrawideEnabled;
-
-    // HideUI
-    public static ConfigEntry<bool> ConfigHideMoneyInSpecialScenes => Configs.HideMoneyInSpecialScenes;
-    public static ConfigEntry<bool> ConfigHideButtonGuide          => Configs.HideButtonGuide;
-    public static ConfigEntry<bool> ConfigHideLikabilityGauge      => Configs.HideLikabilityGauge;
-
-    // Input
-    public static ConfigEntry<float>            ConfigControllerTriggerDeadzone => Configs.ControllerTriggerDeadzone;
-    public static ConfigEntry<ControllerButton> ConfigControllerModifier        => Configs.ControllerModifier;
-
-    // Internal
-    public static ConfigEntry<bool> ConfigExtraActive => Configs.ExtraActive;
-
-    // Time
-    public static HotkeyConfig       ConfigTimeStopToggle   => Configs.TimeStopToggle;
-    public static HotkeyConfig       ConfigFrameAdvance     => Configs.FrameAdvance;
-    public static HotkeyConfig       ConfigFastForward      => Configs.FastForward;
-    public static ConfigEntry<float> ConfigFastForwardSpeed => Configs.FastForwardSpeed;
 
     internal static event Action GUICallback;
 
@@ -132,13 +42,11 @@ public class Plugin : BaseUnityPlugin
         ConfigMigration.Migrate(Config);
 
         // YAML 駆動 Config エントリ（source of truth: Configs.yaml → Generated/Configs.g.cs）。
-        // Plugin.ConfigX は Configs.X への expression-bodied プロパティで転送される。
         // HotkeyConfig (KB+Pad 統合型) も BindAll 内で初期化される。
         Configs.BindAll(Config);
 
-
         // Steam 外起動を検出した場合は Steam 経由で再起動して即終了
-        if (ConfigSteamLaunchCheck.Value && SteamLaunchChecker.CheckAndRelaunchIfNeeded())
+        if (Configs.SteamLaunchCheck.Value && SteamLaunchChecker.CheckAndRelaunchIfNeeded())
         {
             Application.Quit();
             return;
@@ -158,8 +66,8 @@ public class Plugin : BaseUnityPlugin
         Patches.TimeController.Initialize(gameObject);
         SceneManager.sceneUnloaded += Patches.CostumeChanger.PantiesAltSlotMatchPatch.OnSceneUnloaded;
         PatchLogger.LogInfo($"プラグイン起動: {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION}");
-        PatchLogger.LogInfo($"解像度パッチを適用しました: {Plugin.ConfigWidth.Value}x{Plugin.ConfigHeight.Value}");
-        PatchLogger.LogInfo($"アンチエイリアシング設定: {Plugin.ConfigAntiAliasing.Value}");
+        PatchLogger.LogInfo($"解像度パッチを適用しました: {Configs.Width.Value}x{Configs.Height.Value}");
+        PatchLogger.LogInfo($"アンチエイリアシング設定: {Configs.AntiAliasing.Value}");
     }
 
     private void OnDestroy()
@@ -173,10 +81,10 @@ public class Plugin : BaseUnityPlugin
         if (Keyboard.current?[Key.F4].wasPressedThisFrame == true)
             Config.Reload();
 
-        if (ConfigOverlayToggle.IsTriggered())
+        if (Configs.OverlayToggle.IsTriggered())
             ToggleOverlay();
 
-        if (ConfigCaptureScreenshot.IsTriggered())
+        if (Configs.CaptureScreenshot.IsTriggered())
             CaptureScreenshot();
     }
 
@@ -251,7 +159,7 @@ public class Plugin : BaseUnityPlugin
         {
             Directory.CreateDirectory(ScreenshotDirectory);
             string path = Path.Combine(ScreenshotDirectory, $"bg2_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png");
-            ScreenCapture.CaptureScreenshot(path, ConfigScreenshotScale.Value);
+            ScreenCapture.CaptureScreenshot(path, Configs.ScreenshotScale.Value);
             PatchLogger.LogInfo($"スクリーンショットを保存しました: {path}");
         }
         catch (Exception ex)

--- a/BunnyGarden2FixMod/Utils/GamepadHelper.cs
+++ b/BunnyGarden2FixMod/Utils/GamepadHelper.cs
@@ -28,7 +28,7 @@ public static class GamepadHelper
     internal static bool IsButtonHeld(ControllerButton button)
     {
         if (button == ControllerButton.ZL || button == ControllerButton.ZR)
-            return ReadTrigger(button) >= Plugin.ConfigControllerTriggerDeadzone.Value;
+            return ReadTrigger(button) >= Configs.ControllerTriggerDeadzone.Value;
 
         return IsHeld(button);
     }

--- a/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
+++ b/BunnyGarden2FixMod/Utils/HotkeyConfig.cs
@@ -40,7 +40,7 @@ public class HotkeyConfig
     public override string ToString()
     {
         string? keyLabel = KeyConfig == null || KeyConfig.Value == Key.None ? null : KeyConfig.Value.ToString();
-        string? buttonLabel = GetControllerBindingLabel(Plugin.ConfigControllerModifier.Value, ButtonConfig?.Value);
+        string? buttonLabel = GetControllerBindingLabel(Configs.ControllerModifier.Value, ButtonConfig?.Value);
 
         if (keyLabel != null && buttonLabel != null)
             return $"{keyLabel} / {buttonLabel}";
@@ -53,7 +53,7 @@ public class HotkeyConfig
         if (KeyConfig != null && Keyboard.current?[KeyConfig.Value].isPressed == true)
             return true;
 
-        if (ButtonConfig != null && GamepadHelper.IsHeld(Plugin.ConfigControllerModifier.Value) &&
+        if (ButtonConfig != null && GamepadHelper.IsHeld(Configs.ControllerModifier.Value) &&
             GamepadHelper.IsHeld(ButtonConfig.Value))
         {
             return true;
@@ -75,7 +75,7 @@ public class HotkeyConfig
     public bool IsControllerTriggered()
     {
         if (ButtonConfig != null &&
-            IsControllerComboTriggered(Plugin.ConfigControllerModifier.Value, ButtonConfig.Value))
+            IsControllerComboTriggered(Configs.ControllerModifier.Value, ButtonConfig.Value))
         {
             Plugin.SuppressGameInputTemporarily();
             return true;

--- a/BunnyGarden2FixMod/Utils/LiveConfigBinding.cs
+++ b/BunnyGarden2FixMod/Utils/LiveConfigBinding.cs
@@ -15,7 +15,7 @@ namespace BunnyGarden2FixMod.Utils;
 ///
 /// <para>
 /// dedup キーは <see cref="ConfigEntry{T}"/> のインスタンス参照。
-/// <c>Plugin.ConfigXxx</c> は expression-bodied プロパティで同一の <c>Configs.Xxx</c> を返すため
+/// <c>Configs.Xxx</c> は YAML 駆動で 1 度だけ Bind された同一 <see cref="ConfigEntry{T}"/> を返すため
 /// 同 entry に対しては必ず dedup が効く。
 /// </para>
 ///
@@ -26,7 +26,7 @@ namespace BunnyGarden2FixMod.Utils;
 /// public static class FooPatch
 /// {
 ///     private static void Postfix()
-///         =&gt; LiveConfigBinding.BindAndApply(Plugin.ConfigFoo, Apply);
+///         =&gt; LiveConfigBinding.BindAndApply(Configs.Foo, Apply);
 ///
 ///     private static void Apply() { /* … */ }
 /// }


### PR DESCRIPTION
## 概要
`Plugin.cs` に存在した `Plugin.ConfigX => Configs.X` 形式の expression-bodied 転送プロパティ (67 entries / 約 88 行) は、YAML 駆動で生成される `Configs.X` への単なる転送層であり、二重定義による認知負荷と grep / Go-to-Definition の遠回りを生んでいた。本 PR で全呼び出し側を `Configs.X` 直接参照に統一し、転送層を撤去する。機能変更はない。

## 主な変更点
- **refactor**: `Plugin.cs` から forwarding プロパティ群を削除（67 entries）
- **refactor**: 全呼び出し側 (35 ファイル / 118 箇所) を `Plugin.ConfigX` → `Configs.X` に機械置換
- **refactor**: `Plugin.cs` 内 bare 参照 (`ConfigSteamLaunchCheck` 等) も `Configs.X` に修正
- **chore**: `LiveConfigBinding.cs` の XML doc を、転送プロパティ前提の記述から `ConfigEntry` 同一性の直接説明に更新
- **chore**: 不要になった `using BepInEx.Configuration;` を `Plugin.cs` から削除

## 技術的な補足
- `Configs` クラスは `namespace BunnyGarden2FixMod` 直下にあり、配下の `Patches.*` / `Utils.*` などから無修飾で参照可能。`using` 追加は不要
- `Configs.yaml` / `tools/ConfigGen` / `Generated/Configs.g.cs` の生成パイプラインは維持（今回スコープ外）
- `Plugin.ConfigX` は public だったが、本 MOD は単体プラグインで他 MOD からの依存契約を公開していないため、API 互換性は許容範囲

## レビューのポイント
- `Plugin.cs` — forwarding ブロック削除と bare 参照の修正
- `Utils/LiveConfigBinding.cs` — XML doc コメントの書き直しが意味を保っているか

## テスト
- [x] \`dotnet build\` 通過 (BepInEx 5, 0 警告 / 0 エラー)
- [x] BepInEx 6 (\`-p:BepInExVersion=6\`) ビルドはローカル未実施 → CI / マージ前に確認推奨
- [x] 実機での起動確認は未実施（機能変更なしのため低リスク）

## 破壊的変更
なし（\`Plugin.ConfigX\` は内部でのみ参照される public API。外部依存なし）

---

## QA 確認項目

▼ どんな変更をして何を解決したか？
内部リファクタのみ。設定値の参照経路を \`Plugin.ConfigX\` → \`Configs.X\` に一本化し、コードの見通しを良くした。ユーザー視点での挙動変化は一切ない。

▼ 既存影響あるか？
なし（リファクタのみ。設定値・キー・既定値・UI・ホットキー全て同一）

▼ 確認内容
- 全機能（解像度／フリーカメラ／衣装変更／チェキ／チート／HideUI など）が現行版と同一に動作すること
- \`BepInEx/config/net.noeleve.BunnyGarden2FixMod.cfg\` のキー構造が変わらず、既存 cfg がそのまま読めること