### PR TITLE
フリーカメラを別画面にして別角度で表示する

### DIFF
--- a/BunnyGarden2FixMod/Configs.yaml
+++ b/BunnyGarden2FixMod/Configs.yaml
@@ -207,6 +207,7 @@
       default: MainScreen
       description: |
         フリーカメラの映像をどこに表示するかを選択します。
+        排他的フルスクリーンモードの場合は、MainScreen が使用されます。
         MainScreen: メイン画面（通常のフリーカメラ）
         PiP: ピクチャー・イン・ピクチャー
         Display2: サブモニター（モニター2台以上のときのみ）

--- a/BunnyGarden2FixMod/Configs.yaml
+++ b/BunnyGarden2FixMod/Configs.yaml
@@ -649,6 +649,17 @@
       ui:
         kind: keybinding
 
+    - name: FreeCamDisplayModeToggle
+      label: フリーカメラの出力先切替
+      key: ToggleFreeCamDisplayMode
+      type: hotkey
+      defaultKey: F4
+      defaultButton: None
+      description: FreeCamDisplayMode 設定の値を順番に切り替えます。フリーカメラ起動中のみ有効。
+      controllerDescription: ControllerModifier と同時押しが必要です。
+      ui:
+        kind: keybinding
+
     - name: OverlayToggle
       label: オーバーレイ表示切替
       key: ToggleOverlay

--- a/BunnyGarden2FixMod/Configs.yaml
+++ b/BunnyGarden2FixMod/Configs.yaml
@@ -200,6 +200,16 @@
       ui:
         kind: toggle
 
+    - name: UseMultipleDisplays
+      label: フリーカメラで複数モニターを活用
+      type: bool
+      default: false
+      description: |
+        フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。
+        ウィンドウモードかサブモニターがない場合はこの設定は無視されます。
+      ui:
+        kind: toggle
+
 - section: Animation
   name: アニメーション
   configs:

--- a/BunnyGarden2FixMod/Configs.yaml
+++ b/BunnyGarden2FixMod/Configs.yaml
@@ -200,15 +200,18 @@
       ui:
         kind: toggle
 
-    - name: UseMultipleDisplays
-      label: フリーカメラで複数モニターを活用
-      type: bool
-      default: false
+    - name: FreeCamDisplayMode
+      label: フリーカメラの出力先
+      type: enum
+      enumType: BunnyGarden2FixMod.FreeCamDisplayMode
+      default: MainScreen
       description: |
-        フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。
-        ウィンドウモードかサブモニターがない場合はこの設定は無視されます。
+        フリーカメラの映像をどこに表示するかを選択します。
+        MainScreen: メイン画面（通常のフリーカメラ）
+        PiP: ピクチャー・イン・ピクチャー
+        Display2: サブモニター（モニター2台以上のときのみ）
       ui:
-        kind: toggle
+        kind: dropdown
 
 - section: Animation
   name: アニメーション

--- a/BunnyGarden2FixMod/Configs/Enums.cs
+++ b/BunnyGarden2FixMod/Configs/Enums.cs
@@ -19,3 +19,18 @@ public enum ChekiImageFormat
     /// <summary>JPG 劣化圧縮。サイズ 1/20〜1/50・エンコード 30〜100ms/枚</summary>
     JPG,
 }
+
+/// <summary>
+/// フリーカメラの映像をどのディスプレイに出力するかのモード。
+/// </summary>
+public enum FreeCamDisplayMode
+{
+    /// <summary>フリーカメラをメインディスプレイに出力</summary>
+    MainScreen = 0,
+
+    /// <summary>フリーカメラをサブモニター(PiP)に出力</summary>
+    PiP = 1,
+
+    /// <summary>フリーカメラをサブモニター(Display2)に出力（フルスクリーン時のみ）</summary>
+    Display2 = 2,
+}

--- a/BunnyGarden2FixMod/Generated/Configs.g.cs
+++ b/BunnyGarden2FixMod/Generated/Configs.g.cs
@@ -47,6 +47,8 @@ public static class Configs
     public static ConfigEntry<bool> HideGameUiInFreeCam;
     /// <summary>フリーカメラ操作にゲームパッド入力を使用</summary>
     public static ConfigEntry<bool> ControllerEnabled;
+    /// <summary>フリーカメラで複数モニターを活用</summary>
+    public static ConfigEntry<bool> UseMultipleDisplays;
     /// <summary>バーの背景キャスト 2 人の会話リアクションモーションを多様化</summary>
     public static ConfigEntry<bool> MoreTalkReactions;
     /// <summary>一部モーションでスカートが体にめり込む現象を補正</summary>
@@ -230,6 +232,12 @@ Off / FXAA / TAA / MSAA2x / MSAA4x / MSAA8x。
         ControllerEnabled = cfg.Bind("Camera", "ControllerEnabled",
             true,
             @"フリーカメラ操作にゲームパッド入力を使用");
+
+        UseMultipleDisplays = cfg.Bind("Camera", "UseMultipleDisplays",
+            false,
+            @"フリーカメラで複数モニターを活用
+フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。
+ウィンドウモードかサブモニターがない場合はこの設定は無視されます。");
 
         MoreTalkReactions = cfg.Bind("Animation", "MoreTalkReactions",
             false,
@@ -631,6 +639,14 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
             Desc     = "",
             Kind     = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Toggle,
             Accessor = new global::BunnyGarden2FixMod.Patches.Settings.BoolAccessor(() => ControllerEnabled),
+        },
+        new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
+        {
+            Category = "Camera",
+            Label    = "フリーカメラで複数モニターを活用",
+            Desc     = "フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。\nウィンドウモードかサブモニターがない場合はこの設定は無視されます。\n",
+            Kind     = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Toggle,
+            Accessor = new global::BunnyGarden2FixMod.Patches.Settings.BoolAccessor(() => UseMultipleDisplays),
         },
         new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
         {

--- a/BunnyGarden2FixMod/Generated/Configs.g.cs
+++ b/BunnyGarden2FixMod/Generated/Configs.g.cs
@@ -47,8 +47,8 @@ public static class Configs
     public static ConfigEntry<bool> HideGameUiInFreeCam;
     /// <summary>フリーカメラ操作にゲームパッド入力を使用</summary>
     public static ConfigEntry<bool> ControllerEnabled;
-    /// <summary>フリーカメラで複数モニターを活用</summary>
-    public static ConfigEntry<bool> UseMultipleDisplays;
+    /// <summary>フリーカメラの出力先</summary>
+    public static ConfigEntry<BunnyGarden2FixMod.FreeCamDisplayMode> FreeCamDisplayMode;
     /// <summary>バーの背景キャスト 2 人の会話リアクションモーションを多様化</summary>
     public static ConfigEntry<bool> MoreTalkReactions;
     /// <summary>一部モーションでスカートが体にめり込む現象を補正</summary>
@@ -233,11 +233,13 @@ Off / FXAA / TAA / MSAA2x / MSAA4x / MSAA8x。
             true,
             @"フリーカメラ操作にゲームパッド入力を使用");
 
-        UseMultipleDisplays = cfg.Bind("Camera", "UseMultipleDisplays",
-            false,
-            @"フリーカメラで複数モニターを活用
-フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。
-ウィンドウモードかサブモニターがない場合はこの設定は無視されます。");
+        FreeCamDisplayMode = cfg.Bind("Camera", "FreeCamDisplayMode",
+            BunnyGarden2FixMod.FreeCamDisplayMode.MainScreen,
+            @"フリーカメラの出力先
+フリーカメラの映像をどこに表示するかを選択します。
+MainScreen: メイン画面（通常のフリーカメラ）
+PiP: ピクチャー・イン・ピクチャー
+Display2: サブモニター（モニター2台以上のときのみ）");
 
         MoreTalkReactions = cfg.Bind("Animation", "MoreTalkReactions",
             false,
@@ -643,10 +645,11 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
         new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
         {
             Category = "Camera",
-            Label    = "フリーカメラで複数モニターを活用",
-            Desc     = "フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。\nウィンドウモードかサブモニターがない場合はこの設定は無視されます。\n",
-            Kind     = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Toggle,
-            Accessor = new global::BunnyGarden2FixMod.Patches.Settings.BoolAccessor(() => UseMultipleDisplays),
+            Label    = "フリーカメラの出力先",
+            Desc     = "フリーカメラの映像をどこに表示するかを選択します。\nMainScreen: メイン画面（通常のフリーカメラ）\nPiP: ピクチャー・イン・ピクチャー\nDisplay2: サブモニター（モニター2台以上のときのみ）\n",
+            Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Dropdown,
+            DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.FreeCamDisplayMode)),
+            Accessor        = new global::BunnyGarden2FixMod.Patches.Settings.EnumAccessor<global::BunnyGarden2FixMod.FreeCamDisplayMode>(() => FreeCamDisplayMode),
         },
         new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
         {

--- a/BunnyGarden2FixMod/Generated/Configs.g.cs
+++ b/BunnyGarden2FixMod/Generated/Configs.g.cs
@@ -117,6 +117,8 @@ public static class Configs
     public static global::BunnyGarden2FixMod.Utils.HotkeyConfig FreeCamToggle;
     /// <summary>固定フリーカメラ ON/OFF</summary>
     public static global::BunnyGarden2FixMod.Utils.HotkeyConfig FixedFreeCamToggle;
+    /// <summary>フリーカメラの出力先切替</summary>
+    public static global::BunnyGarden2FixMod.Utils.HotkeyConfig FreeCamDisplayModeToggle;
     /// <summary>オーバーレイ表示切替</summary>
     public static global::BunnyGarden2FixMod.Utils.HotkeyConfig OverlayToggle;
     /// <summary>スクリーンショット保存</summary>
@@ -466,6 +468,14 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
             global::BunnyGarden2FixMod.Utils.ControllerButton.X,
             @"固定フリーカメラ ON/OFF",
             @"フリーカメラ起動中にカメラ位置を固定します。フリーカメラ起動中のみ有効。",
+            @"ControllerModifier と同時押しが必要です。");
+
+        FreeCamDisplayModeToggle = new global::BunnyGarden2FixMod.Utils.HotkeyConfig(cfg,
+            "Hotkey", "ToggleFreeCamDisplayMode",
+            global::UnityEngine.InputSystem.Key.F4,
+            global::BunnyGarden2FixMod.Utils.ControllerButton.None,
+            @"フリーカメラの出力先切替",
+            @"FreeCamDisplayMode 設定の値を順番に切り替えます。フリーカメラ起動中のみ有効。",
             @"ControllerModifier と同時押しが必要です。");
 
         OverlayToggle = new global::BunnyGarden2FixMod.Utils.HotkeyConfig(cfg,
@@ -941,6 +951,15 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
             Desc     = "フリーカメラ起動中にカメラ位置を固定します。フリーカメラ起動中のみ有効。",
             Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.KeyBinding,
             HotkeyProvider  = () => FixedFreeCamToggle,
+            DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.Utils.ControllerButton)),
+        },
+        new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
+        {
+            Category = "Hotkey",
+            Label    = "フリーカメラの出力先切替",
+            Desc     = "FreeCamDisplayMode 設定の値を順番に切り替えます。フリーカメラ起動中のみ有効。",
+            Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.KeyBinding,
+            HotkeyProvider  = () => FreeCamDisplayModeToggle,
             DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.Utils.ControllerButton)),
         },
         new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta

--- a/BunnyGarden2FixMod/Generated/Configs.g.cs
+++ b/BunnyGarden2FixMod/Generated/Configs.g.cs
@@ -237,6 +237,7 @@ Off / FXAA / TAA / MSAA2x / MSAA4x / MSAA8x。
             BunnyGarden2FixMod.FreeCamDisplayMode.MainScreen,
             @"フリーカメラの出力先
 フリーカメラの映像をどこに表示するかを選択します。
+排他的フルスクリーンモードの場合は、MainScreen が使用されます。
 MainScreen: メイン画面（通常のフリーカメラ）
 PiP: ピクチャー・イン・ピクチャー
 Display2: サブモニター（モニター2台以上のときのみ）");
@@ -646,7 +647,7 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
         {
             Category = "Camera",
             Label    = "フリーカメラの出力先",
-            Desc     = "フリーカメラの映像をどこに表示するかを選択します。\nMainScreen: メイン画面（通常のフリーカメラ）\nPiP: ピクチャー・イン・ピクチャー\nDisplay2: サブモニター（モニター2台以上のときのみ）\n",
+            Desc     = "フリーカメラの映像をどこに表示するかを選択します。\n排他的フルスクリーンモードの場合は、MainScreen が使用されます。\nMainScreen: メイン画面（通常のフリーカメラ）\nPiP: ピクチャー・イン・ピクチャー\nDisplay2: サブモニター（モニター2台以上のときのみ）\n",
             Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Dropdown,
             DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.FreeCamDisplayMode)),
             Accessor        = new global::BunnyGarden2FixMod.Patches.Settings.EnumAccessor<global::BunnyGarden2FixMod.FreeCamDisplayMode>(() => FreeCamDisplayMode),

--- a/BunnyGarden2FixMod/Patches/AntiAliasingPatch.cs
+++ b/BunnyGarden2FixMod/Patches/AntiAliasingPatch.cs
@@ -42,9 +42,8 @@ public static class MsaaSetupPatch
     private static void Postfix()
         => LiveConfigBinding.BindAndApply(Configs.AntiAliasing, Apply);
 
-    private static void Apply()
-    {
-        int msaaSamples = Configs.AntiAliasing.Value switch
+    public static int GetMSAASamples()
+        => Configs.AntiAliasing.Value switch
         {
             AntiAliasingType.MSAA2x => 2,
             AntiAliasingType.MSAA4x => 4,
@@ -52,6 +51,9 @@ public static class MsaaSetupPatch
             _ => 1,
         };
 
+    private static void Apply()
+    {
+        int msaaSamples = GetMSAASamples();
         if (GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset urpAsset)
         {
             // MSAA 以外への切替時に sampleCount を 1 へ戻す必要があるため、

--- a/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
@@ -1,3 +1,4 @@
+using BunnyGarden2FixMod.Patches.FreeCamera;
 using BunnyGarden2FixMod.Utils;
 using GB.Save;
 using HarmonyLib;
@@ -186,8 +187,9 @@ public static class ChekiResolutionPatch
 
         yield return new WaitForEndOfFrame();
 
-        // フリーカメラがDisplay2を使用する時のみ，Cameraからのキャプチャを使用する
-        bool useMainCameraCapture = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2;
+        // フリーカメラがアクティブかつDisplay2を使用する時のみ，Cameraからのキャプチャを使用する
+        bool useMainCameraCapture = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2 &&
+                                    FreeCameraManager.IsActive;
 
         if (useMainCameraCapture)
         {

--- a/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
@@ -186,9 +186,8 @@ public static class ChekiResolutionPatch
 
         yield return new WaitForEndOfFrame();
 
-        // フリーカメラでないか，PiP, MainScreenのときは ScreenShotを使用
-        bool useMainCameraCapture = Patches.FreeCamera.FreeCameraManager.IsActive &&
-                                    Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2;
+        // フリーカメラがDisplay2を使用する時のみ，Cameraからのキャプチャを使用する
+        bool useMainCameraCapture = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2;
 
         if (useMainCameraCapture)
         {
@@ -197,6 +196,7 @@ public static class ChekiResolutionPatch
         }
         else
         {
+            // スクリーンショットから画像を取得
             s_captureRef(self) = ScreenCapture.CaptureScreenshotAsTexture();
         }
 

--- a/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
+++ b/BunnyGarden2FixMod/Patches/ChekiResolutionPatch.cs
@@ -186,8 +186,20 @@ public static class ChekiResolutionPatch
 
         yield return new WaitForEndOfFrame();
 
-        // 画面の実アスペクト比でキャプチャを取得。
-        s_captureRef(self) = ScreenCapture.CaptureScreenshotAsTexture();
+        // フリーカメラでないか，PiP, MainScreenのときは ScreenShotを使用
+        bool useMainCameraCapture = Patches.FreeCamera.FreeCameraManager.IsActive &&
+                                    Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2;
+
+        if (useMainCameraCapture)
+        {
+            // メインカメラの現在の画像を直接取得
+            s_captureRef(self) = CaptureMainCameraTexture();
+        }
+        else
+        {
+            s_captureRef(self) = ScreenCapture.CaptureScreenshotAsTexture();
+        }
+
         var capture = s_captureRef(self);
         float captureAspect = (float)capture.width / Mathf.Max(1, capture.height);
 
@@ -266,4 +278,49 @@ public static class ChekiResolutionPatch
             Object.Destroy(hiRT);
         }
     }
+
+    // Display2を用いているときは，メインカメラの画像をキャプチャする
+    private static Texture2D CaptureMainCameraTexture()
+    {
+        Camera targetCam = null;
+        foreach (var cam in Camera.allCameras)
+        {
+            if (cam.targetDisplay == 0 && cam.enabled)
+            {
+                targetCam = cam;
+                break;
+            }
+        }
+
+        if (targetCam == null) targetCam = Camera.main;
+        if (targetCam == null) return null;
+
+        int width = targetCam.pixelWidth;
+        int height = targetCam.pixelHeight;
+
+        var tempRT = RenderTexture.GetTemporary(
+            width, height, 24,
+            RenderTextureFormat.Default,
+            RenderTextureReadWrite.Default);
+        var prevRT = targetCam.targetTexture;
+        var prevActive = RenderTexture.active;
+
+        targetCam.targetTexture = tempRT;
+        targetCam.Render();
+
+        RenderTexture.active = tempRT;
+
+        bool linear = QualitySettings.activeColorSpace == ColorSpace.Linear;
+        Texture2D tex = new Texture2D(width, height, TextureFormat.RGBA32, false, linear);
+
+        tex.ReadPixels(new Rect(0, 0, width, height), 0, 0, false);
+        tex.Apply();
+
+        targetCam.targetTexture = prevRT;
+        RenderTexture.active = prevActive;
+        RenderTexture.ReleaseTemporary(tempRT);
+
+        return tex;
+    }
+
 }

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -3,7 +3,6 @@ using GB;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Rendering.Universal;
-using VLB;
 
 namespace BunnyGarden2FixMod.Patches.FreeCamera;
 
@@ -45,7 +44,7 @@ public class FreeCameraManager : MonoBehaviour
             ToggleFixedFreeCam();
 
         if (Configs.FreeCamDisplayModeToggle.IsTriggered())
-            ChangeFreeCamMode();
+            ToggleFreeCamMode();
     }
 
     private void ToggleFreeCam()
@@ -56,9 +55,10 @@ public class FreeCameraManager : MonoBehaviour
             Activate();
     }
 
-    private void ChangeFreeCamMode()
+    private void ToggleFreeCamMode()
     {
-        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && Screen.fullScreen;
+        bool isFullScreen = Screen.fullScreen || Screen.fullScreenMode == FullScreenMode.FullScreenWindow;
+        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && isFullScreen;
         if (!IsActive || isExclusiveFullScreen) // 排他フルスクリーンモードの場合は、フリーカメラの表示モードを切り替えない
             return;
 
@@ -66,15 +66,20 @@ public class FreeCameraManager : MonoBehaviour
         Configs.FreeCamDisplayMode.Value = Configs.FreeCamDisplayMode.Value switch
         {
             FreeCamDisplayMode.MainScreen => FreeCamDisplayMode.PiP,
-            FreeCamDisplayMode.PiP => Screen.fullScreen ? FreeCamDisplayMode.Display2 : FreeCamDisplayMode.MainScreen,
+            FreeCamDisplayMode.PiP => isFullScreen ? FreeCamDisplayMode.Display2 : FreeCamDisplayMode.MainScreen,
             _ => FreeCamDisplayMode.MainScreen
         };
 
-        Deactivate();
-        Activate();
+        StartCoroutine(RebootFreeCamRoutine()); // Pip表示を安定させるため deactivate->activate を1フレーム遅らせる
         Plugin.Logger.LogInfo("フリーカメラ切替: " + Configs.FreeCamDisplayMode.Value);
     }
 
+    private System.Collections.IEnumerator RebootFreeCamRoutine()
+    {
+        Deactivate();
+        yield return null;
+        Activate();
+    }
 
     private void ToggleFixedFreeCam()
     {
@@ -106,7 +111,8 @@ public class FreeCameraManager : MonoBehaviour
 
         // フリーカメラの映像をどのディスプレイに出力するかのモードを判定
         // 排他的フルスクリーンモードの場合は、不安定になる可能性があるため、Display2出力モードとPiPモードを無効化する
-        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && Screen.fullScreen;
+        bool isFullScreen = Screen.fullScreen || Screen.fullScreenMode == FullScreenMode.FullScreenWindow;
+        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && isFullScreen;
         bool useDisplay2InFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2 && Display.displays.Length > 1;
         bool usePiPInFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.PiP;
 
@@ -120,8 +126,19 @@ public class FreeCameraManager : MonoBehaviour
         else if (useDisplay2InFreeCam && !isExclusiveFullScreen)
         {
             // Display2出力モードでは、フリーカメラをDisplay2に出力する
+
+            // Display.Activateの副作用でフルスクリーンが解除されるので，解像度とモードを保存して復元
+            // 現在の解像度とフルスクリーンモードを保存
+            int currentWidth = Screen.width;
+            int currentHeight = Screen.height;
+            var currentMode = Screen.fullScreenMode;
+
             Display.displays[1].Activate();
             freeCam.targetDisplay = 1;
+
+            // 解像度を復元することで、フルスクリーン状態も一緒に復元される
+            Screen.SetResolution(currentWidth, currentHeight, currentMode, Screen.currentResolution.refreshRateRatio);
+
             originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
             Plugin.Logger.LogInfo("Display2でフリーカメラを有効化");
         }
@@ -145,14 +162,17 @@ public class FreeCameraManager : MonoBehaviour
 
     public void Deactivate()
     {
-        CleanupPiP();
-
         if (freeCamObject != null)
         {
+            var cam = freeCamObject.GetComponent<Camera>();
+            if (cam != null)
+                cam.targetTexture = null;
             StartCoroutine(BlackoutAndDestroyRoutine(freeCamObject)); // ブラックアウトと破棄をコルーチンで実行
             freeCamObject = null;
             controller = null;
         }
+
+        CleanupPiP();
 
         if (originalCam != null)
         {
@@ -194,14 +214,15 @@ public class FreeCameraManager : MonoBehaviour
 
         pipRenderTexture = new RenderTexture(pipWidth, pipHeight, 16);
         pipRenderTexture.antiAliasing = MsaaSetupPatch.GetMSAASamples();
-
         pipRenderTexture.Create();
+
         if (freeCamObject != null)
         {
             var cam = freeCamObject.GetComponent<Camera>();
-            if (cam != null && cam.targetTexture != pipRenderTexture)
+            if (cam != null)
             {
                 cam.targetTexture = pipRenderTexture;
+                cam.enabled = true;
             }
         }
 
@@ -213,7 +234,7 @@ public class FreeCameraManager : MonoBehaviour
         image.raycastTarget = true;
 
         // ドラッグによる移動とリサイズ用のコンポーネントを追加
-        var pipHandler = pipUIObject.AddComponent<PiPHandler>();
+        var pipHandler = pipUIObject.AddComponent<FreeCameraPiPHandler>();
         pipHandler.TargetAspectRatio = pipAspectRatio;
         // PiPのリサイズが確定したときにテクスチャもリサイズするようにコールバックを設定
         pipHandler.OnResizeCommitted = (newWidth, newHeight) =>
@@ -280,112 +301,9 @@ public class FreeCameraManager : MonoBehaviour
         }
         return maxOrder;
     }
-    // PiPのドラッグで，移動とリサイズを管理するクラス
-    private class PiPHandler : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDragHandler
-    {
-        private RectTransform rectTransform;
-        private const float EdgeSize = 30f; // ドラッグでリサイズするエリアのサイズ
-        public float TargetAspectRatio { get; set; } = 16f / 9f; // デフォルトの縦横比
-        private enum DragMode
-        {
-            None,
-            Move,
-            Resize
-        }
-        private DragMode currentDragMode = DragMode.None;
-        private bool isLeft, isRight, isTop, isBottom;
-        public System.Action<int, int> OnResizeCommitted; // リサイズ確定時のコールバック（幅と高さを引数に）
-
-        void Awake()
-        {
-            rectTransform = GetComponent<RectTransform>();
-        }
-        public void OnPointerDown(PointerEventData eventData)
-        {
-            // 常に最前面に持ってくる
-            rectTransform.SetAsLastSibling();
-
-             // --- ドラッグ開始時の判定 ---
-            Vector2 localPoint;
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, eventData.pressPosition, eventData.pressEventCamera, out localPoint);
-
-            float width = rectTransform.rect.width;
-            float height = rectTransform.rect.height;
-
-            // Pivot(1,0)基準の判定
-            isLeft   = localPoint.x <  EdgeSize - width;
-            isRight  = localPoint.x > -EdgeSize;
-            isBottom = localPoint.y <  EdgeSize;
-            isTop    = localPoint.y > -EdgeSize + height ;
-
-            if (isLeft || isRight || isBottom || isTop)
-            {
-                currentDragMode = DragMode.Resize;
-            }
-            else
-            {
-                currentDragMode = DragMode.Move;
-            }
-        }
-
-        public void OnDrag(PointerEventData eventData)
-        {
-            if (currentDragMode == DragMode.Resize)
-            {
-                // --- リサイズ処理のみ ---
-                Vector2 sizeDelta = rectTransform.sizeDelta;
-                float deltaX = isRight ? eventData.delta.x : (isLeft   ? -eventData.delta.x : 0);
-                float deltaY = isTop   ? eventData.delta.y : (isBottom ? -eventData.delta.y : 0);
-
-                if (Mathf.Abs(deltaX) > Mathf.Abs(deltaY))
-                {
-                    sizeDelta.x += deltaX;
-                    sizeDelta.y = sizeDelta.x / TargetAspectRatio;
-                }
-                else
-                {
-                    sizeDelta.y += deltaY;
-                    sizeDelta.x = sizeDelta.y * TargetAspectRatio;
-                }
-
-                if (sizeDelta.x > 100f && sizeDelta.y > 100f)
-                {
-                    rectTransform.sizeDelta = sizeDelta;
-                }
-            }
-            else if (currentDragMode == DragMode.Move)
-            {
-                // --- 移動処理のみ ---
-                rectTransform.anchoredPosition += eventData.delta;
-            }
-        }
-
-        // ドラッグが終わったら解像度を再設定し，モードをリセット
-        public void OnEndDrag(PointerEventData eventData)
-        {
-            if (currentDragMode == DragMode.Resize)
-            {
-                var rectTransform = GetComponent<RectTransform>();
-                if (rectTransform != null)
-                {
-                    int newWidth = Mathf.RoundToInt(rectTransform.rect.width);
-                    int newHeight = Mathf.RoundToInt(rectTransform.rect.height);
-                    OnResizeCommitted?.Invoke(newWidth, newHeight);
-                    Plugin.Logger.LogInfo($"PiPサイズ変更: {newWidth}x{newHeight}");
-                }
-            }
-            currentDragMode = DragMode.None;
-        }
-    }
 
     private void CleanupPiP()
     {
-        if (freeCamObject != null)
-        {
-            var cam = freeCamObject.GetComponent<Camera>();
-            if (cam != null)
-                cam.targetTexture = null;
-        }
         if (pipRenderTexture != null)
         {
             pipRenderTexture.Release();

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using GB;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.InputSystem;
 using UnityEngine.Rendering.Universal;
 
 namespace BunnyGarden2FixMod.Patches.FreeCamera;
@@ -18,6 +17,8 @@ public class FreeCameraManager : MonoBehaviour
     private readonly Dictionary<EventSystem, bool> eventSystemNavigationStates = [];
     private readonly Dictionary<Canvas, bool> canvasEnabledStates = [];
     private bool isGameUiSuppressed;
+    private RenderTexture pipRenderTexture;
+    private GameObject pipUIObject;
 
     public static FreeCameraManager Initialize(GameObject parent)
         => parent.AddComponent<FreeCameraManager>();
@@ -78,17 +79,31 @@ public class FreeCameraManager : MonoBehaviour
             originalCam.transform.position,
             originalCam.transform.rotation);
 
-        bool isMultiDisplay = Display.displays.Length > 1 && Configs.UseMultipleDisplays.Value && Screen.fullScreen;
-        if(isMultiDisplay)
+        // フリーカメラの映像をどのディスプレイに出力するかのモードを判定
+        bool useDisplay2InFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2 && Display.displays.Length > 1;
+        bool usePiPInFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.PiP;
+
+        if (usePiPInFreeCam)
         {
+            // PiPモードではPiPを起動して、フリーカメラをPiPに出力する
+            SetupPiP();
+            originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
+            Plugin.Logger.LogInfo("PiPモードでフリーカメラを有効化");
+        }
+        else if (useDisplay2InFreeCam)
+        {
+            // Display2出力モードでは、フリーカメラをDisplay2に出力する
             Display.displays[1].Activate();
             freeCam.targetDisplay = 1;
             originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
+            Plugin.Logger.LogInfo("Display2出力モードでフリーカメラを有効化");
         }
         else
         {
+            // どちらのモードも無効な場合は、メインを停止してフリーカメラをメインディスプレイに出力する
             freeCam.targetDisplay = 0;
             originalCam.enabled = false;
+            Plugin.Logger.LogInfo("標準モードでフリーカメラを有効化");
         }
 
         CopyUrpCameraData(originalCam, freeCam);
@@ -108,9 +123,11 @@ public class FreeCameraManager : MonoBehaviour
 
     public void Deactivate()
     {
+        CleanupPiP();
+
         if(freeCamObject != null)
         {
-            StartCoroutine(BlackoutAndDestroyRoutine(freeCamObject));
+            StartCoroutine(BlackoutAndDestroyRoutine(freeCamObject)); // ブラックアウトと破棄をコルーチンで実行
             freeCamObject = null;
             controller = null;
         }
@@ -146,6 +163,68 @@ public class FreeCameraManager : MonoBehaviour
         }
         Destroy(targetCamObject);
     }
+
+    private void SetupPiP()
+    {
+        CleanupPiP();
+        int pipWidth = Screen.width / 4;
+        int pipHeight = Screen.height / 4;
+        pipRenderTexture = new RenderTexture(pipWidth, pipHeight, 16);
+        pipRenderTexture.antiAliasing = Configs.AntiAliasing.Value switch
+        {   // ここでアンチエイリアス強度を指定
+            AntiAliasingType.MSAA2x => 2,
+            AntiAliasingType.MSAA4x => 4,
+            AntiAliasingType.MSAA8x => 8,
+            _ => 1,
+        };
+        pipRenderTexture.Create();
+        if(freeCamObject != null)
+        {
+            var cam = freeCamObject.GetComponent<Camera>();
+            if(cam != null && cam.targetTexture != pipRenderTexture)
+            {
+                cam.targetTexture = pipRenderTexture;
+            }
+        }
+
+        pipUIObject = new GameObject("PiPUI");
+        var image = pipUIObject.AddComponent<UnityEngine.UI.RawImage>();
+        image.texture = pipRenderTexture;
+
+        var canvas = GameObject.Find("Canvas")?.GetComponent<Canvas>();
+        if (canvas != null)
+        {
+            pipUIObject.transform.SetParent(canvas.transform, false);
+            var rect = pipUIObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(1, 0);
+            rect.anchorMax = new Vector2(1, 0);
+            rect.pivot = new Vector2(1, 0);
+            rect.anchoredPosition = new Vector2(0, 0);
+            rect.sizeDelta = new Vector2(pipWidth, pipHeight);
+        }
+    }
+
+    private void CleanupPiP()
+    {
+        if(freeCamObject != null)
+        {
+            var cam = freeCamObject.GetComponent<Camera>();
+            if(cam != null)
+                cam.targetTexture = null;
+        }
+
+        if(pipRenderTexture != null)
+        {
+            pipRenderTexture.Release();
+            Destroy(pipRenderTexture);
+            pipRenderTexture = null;
+        }
+        if (pipUIObject != null)
+        {
+            Destroy(pipUIObject);
+            pipUIObject = null;
+        }
+    }
     private static void CopyUrpCameraData(Camera src, Camera dst)
     {
         var srcData = src.GetUniversalAdditionalCameraData();
@@ -165,8 +244,11 @@ public class FreeCameraManager : MonoBehaviour
 
     public void RefreshGameUiSuppression(bool force = false)
     {
-        bool isMultiDisplay = Display.displays.Length > 1 && Configs.UseMultipleDisplays.Value && Screen.fullScreen;
-        bool shouldSuppress = !isMultiDisplay && IsActive && !IsFixed && !ShouldExposeGameUiDuringFreeCam();
+        bool useDisplay2InFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2 && Display.displays.Length > 1;
+        bool usePiPInFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.PiP;
+        bool isMainScreenOccupied = !usePiPInFreeCam && !useDisplay2InFreeCam;  // メインディスプレイにフリーカメラで占有されているかどうか
+
+        bool shouldSuppress = isMainScreenOccupied && IsActive && !IsFixed && !ShouldExposeGameUiDuringFreeCam();
         if (!force && shouldSuppress == isGameUiSuppressed)
             return;
 

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -19,6 +19,7 @@ public class FreeCameraManager : MonoBehaviour
     private bool isGameUiSuppressed;
     private RenderTexture pipRenderTexture;
     private GameObject pipUIObject;
+    private GameObject pipCanvasObject;
 
     public static FreeCameraManager Initialize(GameObject parent)
         => parent.AddComponent<FreeCameraManager>();
@@ -74,45 +75,42 @@ public class FreeCameraManager : MonoBehaviour
         freeCamObject = new GameObject("BG2FreeCam");
         var freeCam = freeCamObject.AddComponent<Camera>();
         freeCam.CopyFrom(originalCam);
-        
+
         freeCamObject.transform.SetPositionAndRotation(
             originalCam.transform.position,
             originalCam.transform.rotation);
 
         // フリーカメラの映像をどのディスプレイに出力するかのモードを判定
+        // 排他的フルスクリーンモードの場合は、不安定になる可能性があるため、Display2出力モードとPiPモードを無効化する
+        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && Screen.fullScreen;
         bool useDisplay2InFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.Display2 && Display.displays.Length > 1;
         bool usePiPInFreeCam = Configs.FreeCamDisplayMode.Value == FreeCamDisplayMode.PiP;
 
-        if (usePiPInFreeCam)
+        if (usePiPInFreeCam && !isExclusiveFullScreen)
         {
             // PiPモードではPiPを起動して、フリーカメラをPiPに出力する
             SetupPiP();
             originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
-            Plugin.Logger.LogInfo("PiPモードでフリーカメラを有効化");
+            Plugin.Logger.LogInfo("PiPでフリーカメラを有効化");
         }
-        else if (useDisplay2InFreeCam)
+        else if (useDisplay2InFreeCam && !isExclusiveFullScreen)
         {
             // Display2出力モードでは、フリーカメラをDisplay2に出力する
             Display.displays[1].Activate();
             freeCam.targetDisplay = 1;
             originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
-            Plugin.Logger.LogInfo("Display2出力モードでフリーカメラを有効化");
+            Plugin.Logger.LogInfo("Display2でフリーカメラを有効化");
         }
         else
         {
             // どちらのモードも無効な場合は、メインを停止してフリーカメラをメインディスプレイに出力する
             freeCam.targetDisplay = 0;
             originalCam.enabled = false;
-            Plugin.Logger.LogInfo("標準モードでフリーカメラを有効化");
+            Plugin.Logger.LogInfo("MainScreenでフリーカメラを有効化");
         }
 
         CopyUrpCameraData(originalCam, freeCam);
         controller = freeCamObject.AddComponent<FreeCameraController>();
-
-        if(!originalCam.enabled)
-        {
-            freeCamObject.AddComponent<AudioListener>();
-        }
 
         IsActive = true;
         IsFixed = false;
@@ -125,19 +123,17 @@ public class FreeCameraManager : MonoBehaviour
     {
         CleanupPiP();
 
-        if(freeCamObject != null)
+        if (freeCamObject != null)
         {
             StartCoroutine(BlackoutAndDestroyRoutine(freeCamObject)); // ブラックアウトと破棄をコルーチンで実行
             freeCamObject = null;
             controller = null;
         }
-        
-        if(originalCam != null)
+
+        if (originalCam != null)
         {
             originalCam.enabled = true;
             originalCam.targetDisplay = 0;
-            if(originalCam.TryGetComponent<AudioListener>(out var listener))
-                listener.enabled = true;
         }
 
         IsActive = false;
@@ -167,21 +163,19 @@ public class FreeCameraManager : MonoBehaviour
     private void SetupPiP()
     {
         CleanupPiP();
+
         int pipWidth = Screen.width / 4;
         int pipHeight = Screen.height / 4;
+        float pipAspectRatio = (float)pipWidth / pipHeight;
+
         pipRenderTexture = new RenderTexture(pipWidth, pipHeight, 16);
-        pipRenderTexture.antiAliasing = Configs.AntiAliasing.Value switch
-        {   // ここでアンチエイリアス強度を指定
-            AntiAliasingType.MSAA2x => 2,
-            AntiAliasingType.MSAA4x => 4,
-            AntiAliasingType.MSAA8x => 8,
-            _ => 1,
-        };
+        pipRenderTexture.antiAliasing = MsaaSetupPatch.GetMSAASamples();
+
         pipRenderTexture.Create();
-        if(freeCamObject != null)
+        if (freeCamObject != null)
         {
             var cam = freeCamObject.GetComponent<Camera>();
-            if(cam != null && cam.targetTexture != pipRenderTexture)
+            if (cam != null && cam.targetTexture != pipRenderTexture)
             {
                 cam.targetTexture = pipRenderTexture;
             }
@@ -191,7 +185,30 @@ public class FreeCameraManager : MonoBehaviour
         var image = pipUIObject.AddComponent<UnityEngine.UI.RawImage>();
         image.texture = pipRenderTexture;
 
-        var canvas = GameObject.Find("Canvas")?.GetComponent<Canvas>();
+        // レイキャスト（マウス判定）を有効にする
+        image.raycastTarget = true;
+
+        // ドラッグによる移動とリサイズ用のコンポーネントを追加
+        var pipHandler = pipUIObject.AddComponent<PiPHandler>();
+        pipHandler.TargetAspectRatio = pipAspectRatio;
+        // PiPのリサイズが確定したときにテクスチャもリサイズするようにコールバックを設定
+        pipHandler.OnResizeCommitted = (newWidth, newHeight) =>
+        {
+            RefreshTexture(newWidth, newHeight);
+        };
+
+        // PiP用にCanvasを新規作成して、そこにPiPUIを配置する
+        pipCanvasObject = new GameObject("PiPCanvas");
+        var canvas = pipCanvasObject.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+        // ドラッグとリサイズを有効にするためにGraphicRaycasterを追加
+        pipCanvasObject.AddComponent<UnityEngine.UI.GraphicRaycaster>();
+        var scaler = pipCanvasObject.AddComponent<UnityEngine.UI.CanvasScaler>();
+        scaler.uiScaleMode = UnityEngine.UI.CanvasScaler.ScaleMode.ConstantPixelSize;
+        scaler.scaleFactor = 1.0f;
+
+        // PiPUIをCanvasの子にして、右下に配置
         if (canvas != null)
         {
             pipUIObject.transform.SetParent(canvas.transform, false);
@@ -203,17 +220,136 @@ public class FreeCameraManager : MonoBehaviour
             rect.sizeDelta = new Vector2(pipWidth, pipHeight);
         }
     }
+    private void RefreshTexture(int width, int height)
+    {
+        // pipRenderTextureを解放し新規生成
+        if (pipRenderTexture != null)
+        {
+            pipRenderTexture.Release();
+            Destroy(pipRenderTexture);
+        }
+        pipRenderTexture = new RenderTexture(width, height, 16);
+        pipRenderTexture.antiAliasing = MsaaSetupPatch.GetMSAASamples();
+        pipRenderTexture.Create();
+
+        // freeCamObjectを流用し，テクスチャを更新
+        var cam = freeCamObject.GetComponent<Camera>();
+        if (cam != null)
+            cam.targetTexture = pipRenderTexture;
+
+        // pipUIObjectを流用し，テクスチャを更新
+        var image = pipUIObject.GetComponent<UnityEngine.UI.RawImage>();
+        if (image != null)
+            image.texture = pipRenderTexture;
+    }
+
+    // PiPのドラッグで，移動とリサイズを管理するクラス
+    private class PiPHandler : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDragHandler
+    {
+        private RectTransform rectTransform;
+        private const float EdgeSize = 30f; // ドラッグでリサイズするエリアのサイズ
+        public float TargetAspectRatio { get; set; } = 16f / 9f; // デフォルトの縦横比
+        private enum DragMode
+        {
+            None,
+            Move,
+            Resize
+        }
+        private DragMode currentDragMode = DragMode.None;
+        private bool isLeft, isRight, isTop, isBottom;
+        public System.Action<int, int> OnResizeCommitted; // リサイズ確定時のコールバック（幅と高さを引数に）
+
+        void Awake()
+        {
+            rectTransform = GetComponent<RectTransform>();
+        }
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            // 常に最前面に持ってくる
+            rectTransform.SetAsLastSibling();
+
+             // --- ドラッグ開始時の判定 ---
+            Vector2 localPoint;
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, eventData.pressPosition, eventData.pressEventCamera, out localPoint);
+
+            float width = rectTransform.rect.width;
+            float height = rectTransform.rect.height;
+
+            // Pivot(1,0)基準の判定
+            isLeft   = localPoint.x <  EdgeSize - width;
+            isRight  = localPoint.x > -EdgeSize;
+            isBottom = localPoint.y <  EdgeSize;
+            isTop    = localPoint.y > -EdgeSize + height ;
+
+            if (isLeft || isRight || isBottom || isTop)
+            {
+                currentDragMode = DragMode.Resize;
+            }
+            else
+            {
+                currentDragMode = DragMode.Move;
+            }
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            if (currentDragMode == DragMode.Resize)
+            {
+                // --- リサイズ処理のみ ---
+                Vector2 sizeDelta = rectTransform.sizeDelta;
+                float deltaX = isRight ? eventData.delta.x : (isLeft   ? -eventData.delta.x : 0);
+                float deltaY = isTop   ? eventData.delta.y : (isBottom ? -eventData.delta.y : 0);
+
+                if (Mathf.Abs(deltaX) > Mathf.Abs(deltaY))
+                {
+                    sizeDelta.x += deltaX;
+                    sizeDelta.y = sizeDelta.x / TargetAspectRatio;
+                }
+                else
+                {
+                    sizeDelta.y += deltaY;
+                    sizeDelta.x = sizeDelta.y * TargetAspectRatio;
+                }
+
+                if (sizeDelta.x > 100f && sizeDelta.y > 100f)
+                {
+                    rectTransform.sizeDelta = sizeDelta;
+                }
+            }
+            else if (currentDragMode == DragMode.Move)
+            {
+                // --- 移動処理のみ ---
+                rectTransform.anchoredPosition += eventData.delta;
+            }
+        }
+
+        // ドラッグが終わったら解像度を再設定し，モードをリセット
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            if (currentDragMode == DragMode.Resize)
+            {
+                var rectTransform = GetComponent<RectTransform>();
+                if (rectTransform != null)
+                {
+                    int newWidth = Mathf.RoundToInt(rectTransform.rect.width);
+                    int newHeight = Mathf.RoundToInt(rectTransform.rect.height);
+                    OnResizeCommitted?.Invoke(newWidth, newHeight);
+                    Plugin.Logger.LogInfo($"PiPサイズ変更: {newWidth}x{newHeight}");
+                }
+            }
+            currentDragMode = DragMode.None;
+        }
+    }
 
     private void CleanupPiP()
     {
-        if(freeCamObject != null)
+        if (freeCamObject != null)
         {
             var cam = freeCamObject.GetComponent<Camera>();
-            if(cam != null)
+            if (cam != null)
                 cam.targetTexture = null;
         }
-
-        if(pipRenderTexture != null)
+        if (pipRenderTexture != null)
         {
             pipRenderTexture.Release();
             Destroy(pipRenderTexture);
@@ -223,6 +359,11 @@ public class FreeCameraManager : MonoBehaviour
         {
             Destroy(pipUIObject);
             pipUIObject = null;
+        }
+        if (pipCanvasObject != null)
+        {
+            Destroy(pipCanvasObject);
+            pipCanvasObject = null;
         }
     }
     private static void CopyUrpCameraData(Camera src, Camera dst)

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -201,6 +201,7 @@ public class FreeCameraManager : MonoBehaviour
         pipCanvasObject = new GameObject("PiPCanvas");
         var canvas = pipCanvasObject.AddComponent<Canvas>();
         canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.sortingOrder = GetMaxUIOrder() + 1; // 他のUIより前面に表示
 
         // ドラッグとリサイズを有効にするためにGraphicRaycasterを追加
         pipCanvasObject.AddComponent<UnityEngine.UI.GraphicRaycaster>();
@@ -243,6 +244,18 @@ public class FreeCameraManager : MonoBehaviour
             image.texture = pipRenderTexture;
     }
 
+    // 他のUIオブジェクトの最大のソート順序を取得する
+    private int GetMaxUIOrder()
+    {
+        int maxOrder = 0;
+        Canvas[] canvases = FindObjectsByType<Canvas>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+        foreach (var canvas in canvases)
+        {
+            if (canvas != null && canvas.sortingOrder > maxOrder)
+                maxOrder = canvas.sortingOrder;
+        }
+        return maxOrder;
+    }
     // PiPのドラッグで，移動とリサイズを管理するクラス
     private class PiPHandler : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDragHandler
     {

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -73,52 +73,79 @@ public class FreeCameraManager : MonoBehaviour
         freeCamObject = new GameObject("BG2FreeCam");
         var freeCam = freeCamObject.AddComponent<Camera>();
         freeCam.CopyFrom(originalCam);
+        
         freeCamObject.transform.SetPositionAndRotation(
             originalCam.transform.position,
             originalCam.transform.rotation);
 
-        // URP ポストプロセス設定をコピー（CinemachineBrain には触らない）
+        bool isMultiDisplay = Display.displays.Length > 1 && Configs.UseMultipleDisplays.Value && Screen.fullScreen;
+        if(isMultiDisplay)
+        {
+            Display.displays[1].Activate();
+            freeCam.targetDisplay = 1;
+            originalCam.enabled = true; // 元のカメラは引き続きメインディスプレイに出力
+        }
+        else
+        {
+            freeCam.targetDisplay = 0;
+            originalCam.enabled = false;
+        }
+
         CopyUrpCameraData(originalCam, freeCam);
-
         controller = freeCamObject.AddComponent<FreeCameraController>();
-        freeCamObject.gameObject.AddComponent<AudioListener>();
 
-        originalCam.enabled = false;
-        if (originalCam.TryGetComponent<AudioListener>(out var listener))
-            listener.enabled = false;
-
-        Plugin.Logger.LogInfo("フリーカメラを作成しました");
+        if(!originalCam.enabled)
+        {
+            freeCamObject.AddComponent<AudioListener>();
+        }
 
         IsActive = true;
+        IsFixed = false;
+
+        Plugin.Logger.LogInfo("フリーカメラを作成しました");
         RefreshGameUiSuppression(force: true);
     }
 
     public void Deactivate()
     {
-        if (freeCamObject != null)
+        if(freeCamObject != null)
         {
-            Destroy(freeCamObject);
+            StartCoroutine(BlackoutAndDestroyRoutine(freeCamObject));
             freeCamObject = null;
             controller = null;
         }
-
-        if (originalCam != null)
+        
+        if(originalCam != null)
         {
             originalCam.enabled = true;
-
-            if (originalCam.TryGetComponent<AudioListener>(out var listener))
+            originalCam.targetDisplay = 0;
+            if(originalCam.TryGetComponent<AudioListener>(out var listener))
                 listener.enabled = true;
         }
 
         IsActive = false;
         IsFixed = false;
         RefreshGameUiSuppression(force: true);
+
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
 
         Plugin.Logger.LogInfo($"フリーカメラを解除しました");
     }
+    private System.Collections.IEnumerator BlackoutAndDestroyRoutine(GameObject targetCamObject)
+    {
+        // カメラのクリアフラグを「Solid Color」、背景色を黒、カリングマスクを0に設定して、画面全体を黒で塗りつぶす
+        var cam = targetCamObject.GetComponent<Camera>();
+        if (cam != null)
+        {
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = Color.black;
+            cam.cullingMask = 0;
 
+            yield return new WaitForEndOfFrame();
+        }
+        Destroy(targetCamObject);
+    }
     private static void CopyUrpCameraData(Camera src, Camera dst)
     {
         var srcData = src.GetUniversalAdditionalCameraData();
@@ -138,7 +165,8 @@ public class FreeCameraManager : MonoBehaviour
 
     public void RefreshGameUiSuppression(bool force = false)
     {
-        bool shouldSuppress = IsActive && !IsFixed && !ShouldExposeGameUiDuringFreeCam();
+        bool isMultiDisplay = Display.displays.Length > 1 && Configs.UseMultipleDisplays.Value && Screen.fullScreen;
+        bool shouldSuppress = !isMultiDisplay && IsActive && !IsFixed && !ShouldExposeGameUiDuringFreeCam();
         if (!force && shouldSuppress == isGameUiSuppressed)
             return;
 

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -3,6 +3,7 @@ using GB;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Rendering.Universal;
+using VLB;
 
 namespace BunnyGarden2FixMod.Patches.FreeCamera;
 
@@ -42,6 +43,9 @@ public class FreeCameraManager : MonoBehaviour
 
         if (Configs.FixedFreeCamToggle.IsTriggered())
             ToggleFixedFreeCam();
+
+        if (Configs.FreeCamDisplayModeToggle.IsTriggered())
+            ChangeFreeCamMode();
     }
 
     private void ToggleFreeCam()
@@ -51,6 +55,26 @@ public class FreeCameraManager : MonoBehaviour
         else
             Activate();
     }
+
+    private void ChangeFreeCamMode()
+    {
+        bool isExclusiveFullScreen = Configs.ForceExclusiveFullScreen.Value && Screen.fullScreen;
+        if (!IsActive || isExclusiveFullScreen) // 排他フルスクリーンモードの場合は、フリーカメラの表示モードを切り替えない
+            return;
+
+        // モードを切り替え
+        Configs.FreeCamDisplayMode.Value = Configs.FreeCamDisplayMode.Value switch
+        {
+            FreeCamDisplayMode.MainScreen => FreeCamDisplayMode.PiP,
+            FreeCamDisplayMode.PiP => Screen.fullScreen ? FreeCamDisplayMode.Display2 : FreeCamDisplayMode.MainScreen,
+            _ => FreeCamDisplayMode.MainScreen
+        };
+
+        Deactivate();
+        Activate();
+        Plugin.Logger.LogInfo("フリーカメラ切替: " + Configs.FreeCamDisplayMode.Value);
+    }
+
 
     private void ToggleFixedFreeCam()
     {
@@ -494,6 +518,9 @@ public class FreeCameraManager : MonoBehaviour
         GUILayout.Label($"Free Camera: ON ({Configs.FreeCamToggle}=OFF)");
         GUI.color = Color.yellow;
         GUILayout.Label($"Fixed Mode: {(IsFixed ? "ON" : "OFF")} ({Configs.FixedFreeCamToggle}=TOGGLE)");
+        GUI.color = Color.cyan;
+        GUILayout.Label($"Display Mode: {Configs.FreeCamDisplayMode.Value} ({Configs.FreeCamDisplayModeToggle}=TOGGLE)");
         GUI.color = Color.white;
+
     }
 }

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraManager.cs
@@ -147,6 +147,10 @@ public class FreeCameraManager : MonoBehaviour
             // どちらのモードも無効な場合は、メインを停止してフリーカメラをメインディスプレイに出力する
             freeCam.targetDisplay = 0;
             originalCam.enabled = false;
+            freeCamObject.AddComponent<AudioListener>();
+            if (originalCam.TryGetComponent<AudioListener>(out var listener))
+                listener.enabled = false;
+
             Plugin.Logger.LogInfo("MainScreenでフリーカメラを有効化");
         }
 
@@ -178,6 +182,9 @@ public class FreeCameraManager : MonoBehaviour
         {
             originalCam.enabled = true;
             originalCam.targetDisplay = 0;
+
+            if (originalCam.TryGetComponent<AudioListener>(out var listener))
+                listener.enabled = true;
         }
 
         IsActive = false;
@@ -280,13 +287,15 @@ public class FreeCameraManager : MonoBehaviour
 
         // freeCamObjectを流用し，テクスチャを更新
         var cam = freeCamObject.GetComponent<Camera>();
-        if (cam != null)
-            cam.targetTexture = pipRenderTexture;
+        if (cam == null)
+            return;
+        cam.targetTexture = pipRenderTexture;
 
         // pipUIObjectを流用し，テクスチャを更新
         var image = pipUIObject.GetComponent<UnityEngine.UI.RawImage>();
-        if (image != null)
-            image.texture = pipRenderTexture;
+        if (image == null)
+            return;
+        image.texture = pipRenderTexture;
     }
 
     // 他のUIオブジェクトの最大のソート順序を取得する

--- a/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraPiPHandler.cs
+++ b/BunnyGarden2FixMod/Patches/FreeCamera/FreeCameraPiPHandler.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace BunnyGarden2FixMod.Patches.FreeCamera;
+
+/// FreeCameraのPiPウィンドウのドラッグとリサイズを管理するクラス
+public class FreeCameraPiPHandler : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDragHandler
+{
+    private RectTransform rectTransform;
+    private const float EdgeSize = 30f; // ドラッグでリサイズするエリアのサイズ
+    public float TargetAspectRatio { get; set; } = 16f / 9f; // デフォルトの縦横比
+    private enum DragMode
+    {
+        None,
+        Move,
+        Resize
+    }
+    private DragMode currentDragMode = DragMode.None;
+    private bool isLeft, isRight, isTop, isBottom;
+    public System.Action<int, int> OnResizeCommitted; // リサイズ確定時のコールバック（幅と高さを引数に）
+
+    void Awake()
+    {
+        rectTransform = GetComponent<RectTransform>();
+    }
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        // 常に最前面に持ってくる
+        rectTransform.SetAsLastSibling();
+
+            // --- ドラッグ開始時の判定 ---
+        Vector2 localPoint;
+        RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, eventData.pressPosition, eventData.pressEventCamera, out localPoint);
+
+        float width = rectTransform.rect.width;
+        float height = rectTransform.rect.height;
+
+        // Pivot(1,0)基準の判定
+        isLeft   = localPoint.x <  EdgeSize - width;
+        isRight  = localPoint.x > -EdgeSize;
+        isBottom = localPoint.y <  EdgeSize;
+        isTop    = localPoint.y > -EdgeSize + height ;
+
+        if (isLeft || isRight || isBottom || isTop)
+        {
+            currentDragMode = DragMode.Resize;
+        }
+        else
+        {
+            currentDragMode = DragMode.Move;
+        }
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        if (currentDragMode == DragMode.Resize)
+        {
+            // --- リサイズ処理のみ ---
+            Vector2 sizeDelta = rectTransform.sizeDelta;
+            float deltaX = isRight ? eventData.delta.x : (isLeft   ? -eventData.delta.x : 0);
+            float deltaY = isTop   ? eventData.delta.y : (isBottom ? -eventData.delta.y : 0);
+
+            if (Mathf.Abs(deltaX) > Mathf.Abs(deltaY))
+            {
+                sizeDelta.x += deltaX;
+                sizeDelta.y = sizeDelta.x / TargetAspectRatio;
+            }
+            else
+            {
+                sizeDelta.y += deltaY;
+                sizeDelta.x = sizeDelta.y * TargetAspectRatio;
+            }
+
+            if (sizeDelta.x > 100f && sizeDelta.y > 100f)
+            {
+                rectTransform.sizeDelta = sizeDelta;
+            }
+        }
+        else if (currentDragMode == DragMode.Move)
+        {
+            // --- 移動処理のみ ---
+            rectTransform.anchoredPosition += eventData.delta;
+        }
+    }
+
+    // ドラッグが終わったら解像度を再設定し，モードをリセット
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (currentDragMode == DragMode.Resize)
+        {
+            var rectTransform = GetComponent<RectTransform>();
+            if (rectTransform != null)
+            {
+                int newWidth = Mathf.RoundToInt(rectTransform.rect.width);
+                int newHeight = Mathf.RoundToInt(rectTransform.rect.height);
+                OnResizeCommitted?.Invoke(newWidth, newHeight);
+                Plugin.Logger.LogInfo($"PiPサイズ変更: {newWidth}x{newHeight}");
+            }
+        }
+        currentDragMode = DragMode.None;
+    }
+}

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -31,6 +31,7 @@
 | `SlowSpeed` | `0.5` | フリーカメラの低速移動速度 (Ctrl 押下中) |
 | `HideGameUiInFreeCam` | `true` | フリーカメラ起動中にゲーム本体の Canvas を非表示 |
 | `ControllerEnabled` | `true` | フリーカメラ操作にゲームパッド入力を使用 |
+| `UseMultipleDisplays` | `false` | フリーカメラで複数モニターを活用<br>フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。<br>ウィンドウモードかサブモニターがない場合はこの設定は無視されます。 |
 
 フリーカメラは **F5** キーで ON/OFF、**F6** キーでカメラ固定のトグルができます。
 コントローラーの既定操作は **Select + Y** で ON/OFF、フリーカメラ中は **Select + X** で固定切り替え、**Select + B** で時間停止、**Select + A** でスクリーンショット保存です。

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -31,7 +31,7 @@
 | `SlowSpeed` | `0.5` | フリーカメラの低速移動速度 (Ctrl 押下中) |
 | `HideGameUiInFreeCam` | `true` | フリーカメラ起動中にゲーム本体の Canvas を非表示 |
 | `ControllerEnabled` | `true` | フリーカメラ操作にゲームパッド入力を使用 |
-| `UseMultipleDisplays` | `false` | フリーカメラで複数モニターを活用<br>フリーカメラの映像をサブモニターに出力します。Display 1 がゲーム本体、Display 2 以降がフリーカメラになります。<br>ウィンドウモードかサブモニターがない場合はこの設定は無視されます。 |
+| `FreeCamDisplayMode` | `MainScreen` | フリーカメラの出力先<br>フリーカメラの映像をどこに表示するかを選択します。<br>MainScreen: メイン画面（通常のフリーカメラ）<br>PiP: ピクチャー・イン・ピクチャー<br>Display2: サブモニター（モニター2台以上のときのみ） |
 
 フリーカメラは **F5** キーで ON/OFF、**F6** キーでカメラ固定のトグルができます。
 コントローラーの既定操作は **Select + Y** で ON/OFF、フリーカメラ中は **Select + X** で固定切り替え、**Select + B** で時間停止、**Select + A** でスクリーンショット保存です。

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -31,7 +31,7 @@
 | `SlowSpeed` | `0.5` | フリーカメラの低速移動速度 (Ctrl 押下中) |
 | `HideGameUiInFreeCam` | `true` | フリーカメラ起動中にゲーム本体の Canvas を非表示 |
 | `ControllerEnabled` | `true` | フリーカメラ操作にゲームパッド入力を使用 |
-| `FreeCamDisplayMode` | `MainScreen` | フリーカメラの出力先<br>フリーカメラの映像をどこに表示するかを選択します。<br>MainScreen: メイン画面（通常のフリーカメラ）<br>PiP: ピクチャー・イン・ピクチャー<br>Display2: サブモニター（モニター2台以上のときのみ） |
+| `FreeCamDisplayMode` | `MainScreen` | フリーカメラの出力先<br>フリーカメラの映像をどこに表示するかを選択します。<br>排他的フルスクリーンモードの場合は、MainScreen が使用されます。<br>MainScreen: メイン画面（通常のフリーカメラ）<br>PiP: ピクチャー・イン・ピクチャー<br>Display2: サブモニター（モニター2台以上のときのみ） |
 
 フリーカメラは **F5** キーで ON/OFF、**F6** キーでカメラ固定のトグルができます。
 コントローラーの既定操作は **Select + Y** で ON/OFF、フリーカメラ中は **Select + X** で固定切り替え、**Select + B** で時間停止、**Select + A** でスクリーンショット保存です。

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -183,6 +183,8 @@ Wardrobe パネル表示中、以下のキーで操作できます。
 | `ToggleFreeCamButton` | `Y` | フリーカメラ ON/OFFのボタン<br>ControllerModifier と同時押しが必要です。 |
 | `ToggleFixedFreeCamKey` | `F6` | 固定フリーカメラ ON/OFFのキーボードキー<br>フリーカメラ起動中にカメラ位置を固定します。フリーカメラ起動中のみ有効。 |
 | `ToggleFixedFreeCamButton` | `X` | 固定フリーカメラ ON/OFFのボタン<br>フリーカメラ起動中にカメラ位置を固定します。フリーカメラ起動中のみ有効。<br>ControllerModifier と同時押しが必要です。 |
+| `ToggleFreeCamDisplayModeKey` | `F4` | フリーカメラの出力先切替のキーボードキー<br>FreeCamDisplayMode 設定の値を順番に切り替えます。フリーカメラ起動中のみ有効。 |
+| `ToggleFreeCamDisplayModeButton` | `None` | フリーカメラの出力先切替のボタン<br>FreeCamDisplayMode 設定の値を順番に切り替えます。フリーカメラ起動中のみ有効。<br>ControllerModifier と同時押しが必要です。 |
 | `ToggleOverlayKey` | `F12` | オーバーレイ表示切替のキーボードキー<br>フリーカメラの操作ガイドが対象です。 |
 | `ToggleOverlayButton` | `Start` | オーバーレイ表示切替のボタン<br>フリーカメラの操作ガイドが対象です。<br>ControllerModifier と同時押しが必要です。 |
 | `CaptureScreenshotKey` | `P` | スクリーンショット保存のキーボードキー<br>フリーカメラ中にゲーム UI・MOD オーバーレイを写さず BepInEx/screenshots フォルダへ PNG 出力します。 |


### PR DESCRIPTION
## 概要
#37 
F5でフリーカメラに切り替わっていたものをフリーカメラを別画面駆動にすることで2画面でゲームをプレイする。
 
## 変更点
フリーカメラを作成したときに2画面目に割り当て。メインカメラをenableのまま変更しないようにした。
F9の設定画面内で，フリーカメラにどの画面を使用するかどうかを切り替え可能

## 既知の課題
- 複数モニタ使用時，スクリーンショット機能，チェキ機能と連動していない ←解決