### PR TITLE
口パク速さをフレームレートで補正するパッチ

### DIFF
--- a/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
+++ b/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
@@ -13,10 +13,6 @@ namespace BunnyGarden2FixMod.Patches;
 ///
 ///   LipSyncCalculator.Calculate 内で口パクの速度が固定値になっていたため
 /// 　フレームレートが高いと高速になっていた。フレームレートに合わせた数値に書き換える
-///   設定値 = 基準値 0.35f x 60 / FPS
-///    60FPS   → 基準 0.35f (×1.0)
-///    120FPS  → x0.5
-///    240FPS  → x0.25
 /// </summary>
 [HarmonyPatch(typeof(LipSyncCalculator), nameof(LipSyncCalculator.Calculate))]
 public static class LipSyncFpsFixPatch
@@ -35,18 +31,28 @@ public static class LipSyncFpsFixPatch
         var originalMethod = AccessTools.Method(typeof(Mathf), nameof(Mathf.Lerp), new[] { typeof(float), typeof(float), typeof(float) });
         var replacedMethod = AccessTools.Method(typeof(LipSyncFpsFixPatch), nameof(CustomLerp));
 
-        var GetFrequency = typeof(AudioClip).GetProperty("frequency").GetGetMethod();
-        var GetFPSMethod = AccessTools.Method(typeof(LipSyncFpsFixPatch), nameof(GetFPS));
+        var GetFrequencyMethod = AccessTools.PropertyGetter(typeof(AudioClip), nameof(AudioClip.frequency));
+        var GetDeltaTimeMethod = AccessTools.PropertyGetter(typeof(Time), nameof(Time.deltaTime));
 
         int patched = 0;
         for (int i = 0; i < codes.Count; i++)
         {
-            // this.m_clip.frequency / 60 の書き換え
-            if (codes[i].Calls(GetFrequency) &&
-                i+1 < codes.Count && codes[i+1].LoadsConstant(60) &&
-                i+2 < codes.Count && codes[i+2].opcode == OpCodes.Div)
+            // this.m_clip.frequency / 60 を (int)((float)this.m_clip.frequency * deltaTime) に書き換え
+            if (i+2 < codes.Count &&
+                codes[i].Calls(GetFrequencyMethod) &&
+                codes[i+1].LoadsConstant(60) &&
+                codes[i+2].opcode == OpCodes.Div)
             {
-                codes[i+1] = new CodeInstruction(OpCodes.Call, GetFPSMethod);
+                codes[i+1].opcode = OpCodes.Conv_R4;
+                codes[i+1].operand = null;
+
+                codes[i+2].opcode = OpCodes.Call;
+                codes[i+2].operand = GetDeltaTimeMethod;
+
+                codes.Insert(i+3, new CodeInstruction(OpCodes.Mul));
+                codes.Insert(i+4, new CodeInstruction(OpCodes.Conv_I4));
+
+                i += 4;
                 patched++;
                 continue;
             }
@@ -69,15 +75,9 @@ public static class LipSyncFpsFixPatch
 
     private static float CustomLerp(float a, float b, float t)
     {
-        float custom_t = 1.0f - Mathf.Pow(1.0f - t, 60f / (float)GetFPS());
+        float fpsRatio = Time.deltaTime * 60f;
+        float custom_t = 1.0f - Mathf.Pow(1.0f - t, fpsRatio);
         return Mathf.Lerp(a, b, custom_t);
-    }
-
-    private static int GetFPS()
-    {
-        int AppliedFrameRate = Application.targetFrameRate;
-        int FPS = AppliedFrameRate <= 0 ? 60 : AppliedFrameRate;
-        return FPS;
     }
 
 }

--- a/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
+++ b/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
@@ -1,0 +1,62 @@
+using BunnyGarden2FixMod.Utils;
+using GB.Scene;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// 口パクの速度をフレームレートが変わっても同じ速度にするパッチ。
+///
+///   LipSyncCalculator.Calculate 内で口パクの速度が固定値になっていたため
+/// 　フレームレートが高いと高速になっていた。フレームレートに合わせた数値に書き換える
+///   設定値 = 基準値 0.35f x 60 / FPS
+///    60FPS   → 基準 0.35f (×1.0)
+///    120FPS  → x0.5
+///    240FPS  → x0.25
+/// </summary>
+[HarmonyPatch(typeof(LipSyncCalculator), nameof(LipSyncCalculator.Calculate))]
+public static class LipSyncFpsFixPatch
+{
+    private static bool Prepare()
+    {
+        PatchLogger.LogInfo("[LipSyncFpsFixPatch] LipSyncCalculator.Calculate にトランスパイラを登録");
+        return true;
+    }
+
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var codes = new List<CodeInstruction>(instructions);
+
+        var originalMethod = AccessTools.Method(typeof(Mathf), nameof(Mathf.Lerp), new[] { typeof(float), typeof(float), typeof(float) });
+        var replacedMethod = AccessTools.Method(typeof(LipSyncFpsFixPatch), nameof(CustomLerp));
+
+        bool patched = false;
+        for (int i = 0; i < codes.Count; i++)
+        {
+            if (codes[i].opcode == OpCodes.Call && codes[i].operand is MethodInfo method && method == originalMethod)
+            {
+                codes[i].operand = replacedMethod;
+                patched = true;
+            }
+        }
+
+        if(!patched)
+        {
+            PatchLogger.LogError("[LipSyncFpsFixPatch] 修正対象のパターンが見つかりませんでした。ゲームのアップデートでパッチが機能していない可能性があります。");
+        }
+        return codes;
+    }
+
+    private static float CustomLerp(float weight, float num, float t)
+    {
+        int AppliedFrameRate = Application.targetFrameRate;
+        float FPS = AppliedFrameRate <= 0 ? 60f : (float)AppliedFrameRate;
+        float customSpeed = 0.35f * 60f / FPS;
+        return Mathf.Lerp(weight, num, customSpeed);
+    }
+}

--- a/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
+++ b/BunnyGarden2FixMod/Patches/LipSyncFpsFixPatch.cs
@@ -35,28 +35,49 @@ public static class LipSyncFpsFixPatch
         var originalMethod = AccessTools.Method(typeof(Mathf), nameof(Mathf.Lerp), new[] { typeof(float), typeof(float), typeof(float) });
         var replacedMethod = AccessTools.Method(typeof(LipSyncFpsFixPatch), nameof(CustomLerp));
 
-        bool patched = false;
+        var GetFrequency = typeof(AudioClip).GetProperty("frequency").GetGetMethod();
+        var GetFPSMethod = AccessTools.Method(typeof(LipSyncFpsFixPatch), nameof(GetFPS));
+
+        int patched = 0;
         for (int i = 0; i < codes.Count; i++)
         {
+            // this.m_clip.frequency / 60 の書き換え
+            if (codes[i].Calls(GetFrequency) &&
+                i+1 < codes.Count && codes[i+1].LoadsConstant(60) &&
+                i+2 < codes.Count && codes[i+2].opcode == OpCodes.Div)
+            {
+                codes[i+1] = new CodeInstruction(OpCodes.Call, GetFPSMethod);
+                patched++;
+                continue;
+            }
+
+            // lerpの書き換え
             if (codes[i].opcode == OpCodes.Call && codes[i].operand is MethodInfo method && method == originalMethod)
             {
                 codes[i].operand = replacedMethod;
-                patched = true;
+                patched++;
+                continue;
             }
         }
 
-        if(!patched)
+        if(patched != 2)
         {
             PatchLogger.LogError("[LipSyncFpsFixPatch] 修正対象のパターンが見つかりませんでした。ゲームのアップデートでパッチが機能していない可能性があります。");
         }
         return codes;
     }
 
-    private static float CustomLerp(float weight, float num, float t)
+    private static float CustomLerp(float a, float b, float t)
+    {
+        float custom_t = 1.0f - Mathf.Pow(1.0f - t, 60f / (float)GetFPS());
+        return Mathf.Lerp(a, b, custom_t);
+    }
+
+    private static int GetFPS()
     {
         int AppliedFrameRate = Application.targetFrameRate;
-        float FPS = AppliedFrameRate <= 0 ? 60f : (float)AppliedFrameRate;
-        float customSpeed = 0.35f * 60f / FPS;
-        return Mathf.Lerp(weight, num, customSpeed);
+        int FPS = AppliedFrameRate <= 0 ? 60 : AppliedFrameRate;
+        return FPS;
     }
+
 }


### PR DESCRIPTION
## 概要
口パクの速度が高フレームレートで高速になっていたのをパッチで修正しました。

## 修正点
`LipSyncCalculator.Calculate` 内で口パクのスピードが 0.35f 固定になっていたものを，60fpsを基準としてフレームレート（`Application.targetFrameRate`）による補正をしました。
　60FPS   → 基準 0.35 (×1.0)
　f FPS  →  $$1 - (1 - 0.35)^{\frac{60}{f}}$$