### PR TITLE
ミニゲームのときにそよかぜを吹かせるパッチ

### DIFF
--- a/BunnyGarden2FixMod/Configs.yaml
+++ b/BunnyGarden2FixMod/Configs.yaml
@@ -353,6 +353,14 @@
       ui:
         kind: toggle
 
+    - name: SwaySkirtEnabled
+      label: ミニゲーム時にそよかぜを吹かせる
+      type: bool
+      default: false
+      description: ミニゲーム時にそよかぜを吹かせます（デフォルトキー J）
+      ui:
+        kind: toggle
+
 
 - section: CostumeChanger
   name: 衣装変更
@@ -690,6 +698,15 @@
       key: Show
       type: hotkey
       defaultKey: F7
+      defaultButton: None
+      ui:
+        kind: keybinding
+
+    - name: SwaySkirt
+      label: そよかぜを吹かせる（ミニゲームのみ）
+      key: SwaySkirtHotKey
+      type: hotkey
+      defaultKey: J
       defaultButton: None
       ui:
         kind: keybinding

--- a/BunnyGarden2FixMod/Generated/Configs.g.cs
+++ b/BunnyGarden2FixMod/Generated/Configs.g.cs
@@ -71,6 +71,8 @@ public static class Configs
     public static ConfigEntry<bool> CheatLikability;
     /// <summary>バニー系ドリンクを常時メニューに追加</summary>
     public static ConfigEntry<bool> BunnyDrinksEnabled;
+    /// <summary>ミニゲーム時にそよかぜを吹かせる</summary>
+    public static ConfigEntry<bool> SwaySkirtEnabled;
     /// <summary>衣装変更を有効化（要再起動）</summary>
     public static ConfigEntry<bool> CostumeChangerEnabled;
     /// <summary>ゲーム指定衣装を優先</summary>
@@ -127,6 +129,8 @@ public static class Configs
     public static global::BunnyGarden2FixMod.Utils.HotkeyConfig FastForward;
     /// <summary>衣装変更 UI 表示</summary>
     public static global::BunnyGarden2FixMod.Utils.HotkeyConfig CostumeChangerShow;
+    /// <summary>そよかぜを吹かせる（ミニゲームのみ）</summary>
+    public static global::BunnyGarden2FixMod.Utils.HotkeyConfig SwaySkirt;
 
     // ─── BindAll: Plugin.Awake から1回呼ぶ ──────────
     public static void BindAll(ConfigFile cfg)
@@ -305,6 +309,11 @@ F1 で編集モードを開始し、数字キー（1〜5）でキャストを選
             false,
             @"バニー系ドリンクを常時メニューに追加
 BUNNY_TRAP / BUNNY_MAX / BUNNY_PUNCH を進行状況に関わらず常時注文可能にします。");
+
+        SwaySkirtEnabled = cfg.Bind("Cheat", "SwaySkirtEnabled",
+            false,
+            @"ミニゲーム時にそよかぜを吹かせる
+ミニゲーム時にそよかぜを吹かせます（デフォルトキー J）");
 
         CostumeChangerEnabled = cfg.Bind("CostumeChanger", "Enabled",
             true,
@@ -500,6 +509,13 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
             global::UnityEngine.InputSystem.Key.F7,
             global::BunnyGarden2FixMod.Utils.ControllerButton.None,
             @"衣装変更 UI 表示",
+            @"");
+
+        SwaySkirt = new global::BunnyGarden2FixMod.Utils.HotkeyConfig(cfg,
+            "Hotkey", "SwaySkirtHotKey",
+            global::UnityEngine.InputSystem.Key.J,
+            global::BunnyGarden2FixMod.Utils.ControllerButton.None,
+            @"そよかぜを吹かせる（ミニゲームのみ）",
             @"");
 
     }
@@ -739,6 +755,14 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
         },
         new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
         {
+            Category = "Cheat",
+            Label    = "ミニゲーム時にそよかぜを吹かせる",
+            Desc     = "ミニゲーム時にそよかぜを吹かせます（デフォルトキー J）",
+            Kind     = global::BunnyGarden2FixMod.Patches.Settings.UIKind.Toggle,
+            Accessor = new global::BunnyGarden2FixMod.Patches.Settings.BoolAccessor(() => SwaySkirtEnabled),
+        },
+        new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
+        {
             Category = "CostumeChanger",
             Label    = "衣装変更を有効化（要再起動）",
             Desc     = "衣装変更 UI とパッチを有効化します。\nOFF→ON でパッチ適用が必要なため、変更は再起動後に反映されます。\n",
@@ -975,6 +999,15 @@ FastForward ホットキー押下中の Time.timeScale 倍率。",
             Desc     = "",
             Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.KeyBinding,
             HotkeyProvider  = () => CostumeChangerShow,
+            DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.Utils.ControllerButton)),
+        },
+        new global::BunnyGarden2FixMod.Patches.Settings.UIEntryMeta
+        {
+            Category = "Hotkey",
+            Label    = "そよかぜを吹かせる（ミニゲームのみ）",
+            Desc     = "",
+            Kind            = global::BunnyGarden2FixMod.Patches.Settings.UIKind.KeyBinding,
+            HotkeyProvider  = () => SwaySkirt,
             DropdownOptions = global::System.Enum.GetNames(typeof(global::BunnyGarden2FixMod.Utils.ControllerButton)),
         },
     };

--- a/BunnyGarden2FixMod/Patches/SwaySkirtPatch.cs
+++ b/BunnyGarden2FixMod/Patches/SwaySkirtPatch.cs
@@ -1,0 +1,94 @@
+using BunnyGarden2FixMod.Patches.CostumeChanger;
+using BunnyGarden2FixMod.Utils;
+using GB.Scene;
+using HarmonyLib;
+using UnityEngine;
+using static GB.Scene.CharacterHandle;
+
+namespace BunnyGarden2FixMod.Patches;
+
+/// <summary>
+/// ミニゲームのときにそよかぜを吹かせるパッチ
+///
+/// <para>
+/// <b>使い方</b><br/>
+/// ミニゲーム中にHotKeyを押すとそよかぜが吹く
+/// </para>
+/// </summary>
+
+[HarmonyPatch(typeof(CharacterHandle), nameof(CharacterHandle.setup))]
+public static class SwaySkirtPatch
+{
+    private static bool Prepare()
+    {
+        PatchLogger.LogInfo(
+            $"[{nameof(SwaySkirtPatch)}] " +
+            $"{nameof(CharacterHandle)}.{nameof(CharacterHandle.setup)} " +
+            $"をパッチしました。");
+        return true;
+    }
+    private static void Postfix(CharacterHandle __instance)
+    {
+        if (!IsValid(__instance))
+            return;
+
+        if (__instance.m_animator.gameObject.GetComponent<ForceSwayingLoop>() == null)
+        {
+            var loop = __instance.m_animator.gameObject.AddComponent<ForceSwayingLoop>();
+            loop.Initialize(__instance);
+        }
+    }
+
+    // ミニゲームのみで有効。フィッティングルームでは無効
+    // ミニゲーム以外ではlayer 3がなくスカートが揺れない
+    private static bool IsValid(CharacterHandle instance)
+    {
+        return  Configs.SwaySkirtEnabled.Value &&
+                instance?.m_lastLoadArg != null &&
+                instance.m_animator?.gameObject != null &&
+                instance.m_lastLoadArg.AnimatorType == AnimatorType.Minigame &&
+                !CostumeChangerPatch.IsFittingRoomActiveExternal();
+    }
+
+    // SkirtWeightを変更するクラス
+    // HotKeyを押す間，SkirtWeight を 1.0f に，離すと 0.0f にする
+    private class ForceSwayingLoop : MonoBehaviour
+    {
+        private CharacterHandle target;
+        private float currentWeight = 0f;
+        private float transitionSpeed = 5f;
+
+        private void Awake()
+        {
+            Plugin.Logger.LogInfo($"[{nameof(SwaySkirtPatch)}] {nameof(ForceSwayingLoop)}をセットしました");            
+        }
+        private void OnDestroy()
+        {
+            Plugin.Logger.LogInfo($"[{nameof(SwaySkirtPatch)}] {nameof(ForceSwayingLoop)}は破棄されました");            
+        }
+
+        public void Initialize(CharacterHandle handle)
+        {
+            target = handle;
+        }
+
+        private void Update()
+        {
+            if (!IsValid(target))
+            {
+                Destroy(this);
+                return;
+            }
+
+            if (target.m_animator.layerCount <= 3) // layerCountが3になるまで待つ
+                return;
+
+            float targetWeight = Configs.SwaySkirt.IsHeld() ? 1.0f : 0.0f;
+            if (currentWeight != targetWeight)
+            {
+                currentWeight = Mathf.MoveTowards(currentWeight, targetWeight, transitionSpeed * Time.deltaTime);
+                target.SetSkirtWeight(currentWeight);
+            }
+        }
+    }
+}

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -86,6 +86,7 @@
 | `GambleAlwaysWin` | `false` | ギャンブルで負けなくなる（チート） |
 | `Likability` | `false` | 好感度ヒント表示<br>会話選択肢・ドリンク・フードの正解をゲーム内に表示します。<br>【会話選択肢】選択肢テキストの先頭に記号が追加されます。<br>  ★ : 好感度UP（正解）<br>  ▼ : 好感度DOWN（酔い選択肢だが現在の状況では効果なし）<br>【ドリンク・フード】アイテムの背景色が変化します。<br>  緑 : キャストのお気に入り（AddFavoriteLikability > 0）<br>  黄 : 今日の旬アイテム（ボーナスあり）<br>  赤 : キャストが嫌いなもの（AddFavoriteLikability < 0） |
 | `BunnyDrinksEnabled` | `false` | バニー系ドリンクを常時メニューに追加<br>BUNNY_TRAP / BUNNY_MAX / BUNNY_PUNCH を進行状況に関わらず常時注文可能にします。 |
+| `SwaySkirtEnabled` | `false` | ミニゲーム時にそよかぜを吹かせる<br>ミニゲーム時にそよかぜを吹かせます（デフォルトキー J） |
 
 #### キャスト出勤順変更の操作方法
 
@@ -194,4 +195,6 @@ Wardrobe パネル表示中、以下のキーで操作できます。
 | `FastForwardButton` | `None` | 早送りホールドのボタン<br>押している間のみ有効。倍率は FastForwardSpeed で設定。 |
 | `ShowKey` | `F7` | 衣装変更 UI 表示のキーボードキー |
 | `ShowButton` | `None` | 衣装変更 UI 表示のボタン |
+| `SwaySkirtHotKeyKey` | `J` | そよかぜを吹かせる（ミニゲームのみ）のキーボードキー |
+| `SwaySkirtHotKeyButton` | `None` | そよかぜを吹かせる（ミニゲームのみ）のボタン |
 


### PR DESCRIPTION
## 概要
ミニゲームでそよかぜを吹かせることができるようにするパッチ

## 変更点
- `CharacterHandle.setup`が呼ばれたときに，`ForceSwayingLoop`を起動し，`CharacterHandle.SetSkirtWeight` の値を変更
- HotKeyをおすと SkirtWeightを1fに，離すと0fにする

## 備考
- `CharacterHandle.lastLoadArg.AnimatorType == AnimatorType.Minigame` のみ有効。Minigame以外ではスカートのレイヤーがなくて揺れない
