### PR TITLE
fix(costume-changer): おまけモードのミニゲームで F7 衣装変更 UI が開かない問題を修正

### DIFF
--- a/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
+++ b/BunnyGarden2FixMod/Patches/CostumeChanger/UI/CostumePickerController.cs
@@ -307,9 +307,8 @@ public class CostumePickerController : MonoBehaviour
     {
         charId = CharID.NUM;
         var sys = GBSystem.Instance;
-        if (sys == null || !sys.IsIngame) return false;
-        var env = sys.GetActiveEnvScene();
-        if (env == null) return false;
+        if (sys == null) return false;
+        if (GetLiveEnvScene() == null) return false;
 
         if (CostumeChangerPatch.IsFittingRoomActiveExternal()) return false;
 
@@ -481,9 +480,8 @@ public class CostumePickerController : MonoBehaviour
         if (m_loading) return;  // ローディング中は追従しない
 
         var sys = GBSystem.Instance;
-        if (sys == null || !sys.IsIngame) return;
-        var env = sys.GetActiveEnvScene();
-        if (env == null) return;
+        if (sys == null) return;
+        if (GetLiveEnvScene() == null) return;
         var gameData = sys.RefGameData();
         if (gameData == null) return;
 
@@ -542,15 +540,36 @@ public class CostumePickerController : MonoBehaviour
     }
 
     /// <summary>
+    /// ピッカーの開閉・追従判定に使う「生きた EnvScene」を返す。取得できなければ null。
+    ///
+    /// 以前はここで <c>GBSystem.IsIngame</c> も併せて要求していたが、この値は本編プレイ中
+    /// (<c>TitleScene</c> の「はじめから」/ <c>LoadMenu</c> のロード) でしか true にならない。
+    /// おまけ (<c>ExtraScene</c>) のミニゲームは <c>MiniGameBase.SetupEnvSceneForExtra()</c>
+    /// で EnvScene とキャストを読み込むだけで <c>GBSystem.EnterIngame()</c> を通らないため、
+    /// IsIngame == false のままとなり F7 が無反応（「シーン条件不一致」ログ）になっていた。
+    ///
+    /// ピッカーが実際に必要とするのは「キャストが立っている EnvScene があること」だけなので、
+    /// EnvScene の生存のみを条件にする。タイトルや Album などキャストが居ない状況は
+    /// <see cref="GetVisibleCastIds"/> が空を返すことで従来どおり弾かれ、試着室は
+    /// <see cref="CanOpen"/> 側の FittingRoom ガードで引き続き除外される。
+    /// </summary>
+    private static EnvSceneBase GetLiveEnvScene()
+    {
+        var sys = GBSystem.Instance;
+        if (sys == null) return null;
+        var env = sys.GetActiveEnvScene();
+        // Unity の == null は Destroy 済み参照 (fake-null) も null と判定する
+        return env == null ? null : env;
+    }
+
+    /// <summary>
     /// 現在の EnvScene から「Preload 済み + activeInHierarchy」のキャスト一覧を result に詰める。
     /// 呼び出し元は事前に result.Clear() が済んでいることを保証する必要はない（内部で Clear する）。
     /// </summary>
     private static void GetVisibleCastIds(List<CharID> result)
     {
         result.Clear();
-        var sys = GBSystem.Instance;
-        if (sys == null || !sys.IsIngame) return;
-        var env = sys.GetActiveEnvScene();
+        var env = GetLiveEnvScene();
         if (env == null) return;
         for (int i = (int)CharID.KANA; i < (int)CharID.NUM; i++)
         {


### PR DESCRIPTION
## 症状

おまけ（Extra）モードのミニゲーム中に F7 を押しても衣装変更 UI が開かない。
ログには以下だけが出力される。

```
[Info :BunnyGarden2FixMod] [Plugin] [CostumePicker] シーン条件不一致のため開けません
```

本編プレイ中のミニゲームでは正常に開くため、おまけモード側だけの問題。

## 原因

`CostumePickerController` の `CanOpen()` / `CheckCastChanged()` / `GetVisibleCastIds()` が、
開閉条件に `GBSystem.IsIngame` を要求していた。

`IsIngame` が `true` になるのは本編プレイ中だけで、`EnterIngame()` の呼び出し元は
`TitleScene`（「はじめから」）と `LoadMenu`（ロード）の 2 箇所しかない。

一方おまけモードは `TitleScene.enterExtra()` → `ExtraScene` と遷移し、
ミニゲームは `MiniGameBase.SetupEnvSceneForExtra()` で

- `GBSystem.ShowGameRoomScene()` → EnvScene をロード（`GetActiveEnvScene()` は非 null）
- `LoadCharacter()` / `ShowCharacter()` → キャストも表示済み
- `RefGameData().EnterBar()` → `GameData` も有効

という状態を作るが、`EnterIngame()` は通らない。
つまりピッカーに必要な前提はすべて揃っているのに `IsIngame == false` という
一点だけで弾かれていた。

## 修正

`IsIngame` の要求をやめ、「生きた EnvScene があること」だけを条件にする
共通ヘルパ `GetLiveEnvScene()` を追加し、上記 3 箇所を置き換えた。

誤爆しない根拠:

- **タイトル / Album** — キャストは `UnloadCharacter` 済みで `activeInHierarchy == false` のため
  `GetVisibleCastIds()` が空を返し、`CanOpen()` は従来どおり false
- **試着室** — `CanOpen()` の `IsFittingRoomActiveExternal()` ガードで引き続き除外
- **EnvScene 破棄後** — Unity の fake-null により `GetActiveEnvScene() == null` で弾かれる

## 非対象（意図的に据え置き）

- `WardrobeHistoryGate.ShouldRecord()` の `IsIngame` 要求はそのまま。
  Album 等で `m_currentCast` が汚染される問題への対処であり、今回の症状とは別件のため。
- `CastOrderController.CanOpen()` は `HoleScene` + `IsInBar` 判定で、同じ問題は無い。

## 動作確認

- `dotnet build -c Release` — 成功（警告 0 / エラー 0）
- `dotnet test` — 58 件すべてパス（既存テストにリグレッションなし）

再現・確認手順:

1. タイトル → おまけ → ミニゲーム（TWISTER / KARUTA など）を開始
2. F7 を押す → 修正前は無反応、修正後は衣装変更 UI が開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
